### PR TITLE
Use UUID for item_id on versioning table

### DIFF
--- a/db/migrate/20160209121248_change_item_id_on_versions_table.rb
+++ b/db/migrate/20160209121248_change_item_id_on_versions_table.rb
@@ -1,0 +1,6 @@
+class ChangeItemIdOnVersionsTable < ActiveRecord::Migration
+  def change
+    remove_column :versions, :item_id
+    add_column    :versions, :item_id, :uuid, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160201154609) do
+ActiveRecord::Schema.define(version: 20160209121248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,14 +30,12 @@ ActiveRecord::Schema.define(version: 20160201154609) do
 
   create_table "versions", force: :cascade do |t|
     t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
     t.string   "event",          null: false
     t.string   "whodunnit"
     t.jsonb    "object"
     t.jsonb    "object_changes"
     t.datetime "created_at"
+    t.uuid     "item_id",        null: false
   end
-
-  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
 end

--- a/spec/models/escorts/auditing_spec.rb
+++ b/spec/models/escorts/auditing_spec.rb
@@ -16,4 +16,9 @@ RSpec.describe 'Auditing an escort record' do
     expect(escort.versions.count).to eq 3
     expect(escort.versions.third.event).to eq 'destroy'
   end
+
+  it 'assigns the correct item_id to a versioned escort', versioning: true do
+    escort = create(:escort)
+    expect(escort.id).to eq escort.versions.first.item_id
+  end
 end


### PR DESCRIPTION
This fixes a bug whereby paper trail doesn’t record the correct item_id
for the escort model as the column type is set to integer when uuid is
used on the model.
