### PR TITLE
Provide access to the underlying model

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -21,7 +21,7 @@ class Form
 
   def save
     if valid?
-      model.update_attributes(attributes)
+      target.update_attributes(attributes)
       true
     else
       false
@@ -38,11 +38,15 @@ class Form
       send("#{name}_path", model)
   end
 
+  def target
+    model
+  end
+
 private
 
   def load_model_data
     attributes.each_key do |key|
-      public_send("#{key}=", model.send(key))
+      public_send("#{key}=", target.send(key))
     end
   end
 end

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -104,4 +104,10 @@ RSpec.describe Form, type: :form do
       end
     end
   end
+
+  describe '#target' do
+    it 'returns the model' do
+      expect(subject.target).to eq model
+    end
+  end
 end

--- a/spec/forms/identification_spec.rb
+++ b/spec/forms/identification_spec.rb
@@ -105,6 +105,12 @@ RSpec.describe Identification, type: :form do
     end
   end
 
+  describe '#target' do
+    it 'returns the escort model' do
+      expect(subject.target).to eq escort
+    end
+  end
+
   describe '#template' do
     it 'returns the name of the partial to render' do
       expect(subject.template).to eq 'identification'


### PR DESCRIPTION
This allows us to override the target on a form by form
basis so we can save attributes to a nested model on
the escort record.
