### PR TITLE
Summary fixes

### DIFF
--- a/app/assets/stylesheets/_summary.scss
+++ b/app/assets/stylesheets/_summary.scss
@@ -14,6 +14,10 @@
   display: block;
 }
 
+.output {
+  min-height: 25px;
+}
+
 .summary-content {
   background: #F8F8F8;
   padding: 0.5em;

--- a/app/views/escorts/show.html.erb
+++ b/app/views/escorts/show.html.erb
@@ -1,12 +1,7 @@
 <div class="grid-row">
   <div class="column-one-quarter">
     <%= render('shared/navigation') %>
-    <div class="quick-actions">
-      <h2 class="heading-small"><%= t('quick_actions.heading') %></h2>
-      <ul>
-        <li><%= link_to(t('quick_actions.preview'), pdf_path(escort)) %></li>
-      </ul>
-    </div>
+    <%= render('shared/quick_actions') %>
   </div>
   <div class="column-three-quarters">
     <header>

--- a/app/views/escorts/summary.html.erb
+++ b/app/views/escorts/summary.html.erb
@@ -1,6 +1,7 @@
 <div class="grid-row">
   <div class="column-one-quarter">
     <%= render('shared/navigation') %>
+    <%= render('shared/quick_actions') %>
   </div>
   <div class="column-three-quarters">
     <header>

--- a/app/views/shared/_quick_actions.html.erb
+++ b/app/views/shared/_quick_actions.html.erb
@@ -1,0 +1,6 @@
+<div class="quick-actions">
+  <h2 class="heading-small"><%= t('quick_actions.heading') %></h2>
+  <ul>
+    <li><%= link_to(t('quick_actions.preview'), pdf_path(escort)) %></li>
+  </ul>
+</div>


### PR DESCRIPTION
Addresses two issues: 
- Adds 'quick actions' to all forms (was previously not present on summary)
- Prevents summary fields from collapsing

<img width="999" alt="screen shot 2016-02-12 at 12 55 12" src="https://cloud.githubusercontent.com/assets/16000203/13007396/eefd50e6-d187-11e5-8a34-53d7b46cdaaf.png">
