### PR TITLE
Test when an escort already exists

### DIFF
--- a/spec/features/starting_an_escort_spec.rb
+++ b/spec/features/starting_an_escort_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.feature 'searching for a prisoner', type: :feature do
+RSpec.feature 'starting an escort', type: :feature do
   around(:each) do |example|
     travel_to(Date.new(2015, 2, 3)) { example.run }
   end
 
   context 'with a valid prison number' do
-    context 'when prison number is not present' do
-      scenario 'allows to initiate a new PER' do
+    context 'when the prison number does not already exist' do
+      it 'allows the user to initiate a new escort' do
         visit '/'
         fill_in_prison_number 'Z9876XY'
         click_button 'Search'
@@ -19,8 +19,8 @@ RSpec.feature 'searching for a prisoner', type: :feature do
       end
     end
 
-    context 'when prison number is present' do
-      scenario 'shows the prisoner with a link to edit the PER' do
+    context 'when the prison number is exists' do
+      it 'allows the user to edit an existing escort by clicking a link' do
         start_escort_form
         fill_in_identification
         visit '/'
@@ -29,11 +29,24 @@ RSpec.feature 'searching for a prisoner', type: :feature do
         expect(page).to have_link('A1234BC', href: summary_path(Escort.last)).
           and have_content('Bigglesworth, Tarquin 13/02/1972 00:00 03/02/2015')
       end
+
+      context 'the prison number has been persisted in another session' do
+        it 'redirects to the home page' do
+          visit '/'
+          fill_in_prison_number 'Z9876XY'
+          click_button 'Search'
+          # simulate creation of an escort with the same prison number
+          # elsewhere (e.g by another user)
+          create(:escort, :with_prisoner, prison_number: 'Z9876XY')
+          click_button 'Initiate new PER'
+          expect(current_path).to eq root_path
+        end
+      end
     end
   end
 
   context 'with an invalid prison number' do
-    scenario 'shows an error message' do
+    it 'shows an error message' do
       visit '/'
       fill_in_prison_number 'invalid_prison_number'
       click_button 'Search'


### PR DESCRIPTION
Provides a test for the rare case when a prison
number is no longer unique - for example it has
already been created in an alternate session by
another user.

At the moment we just redirect to the home page
when this happens.

This renames the search escort feature to account 
for the addition of this particular test. The home
page although providing search functionality is
also the point in which a user can create and seed
a new escort(with a prison number) or edit an
existing one.
