### PR TITLE
Remove and rename fields on RiskInformation

### DIFF
--- a/app/forms/risks.rb
+++ b/app/forms/risks.rb
@@ -1,11 +1,10 @@
 class Risks < Form
   include Form::TextToggleAttribute
 
-  GENERAL = %i[ to_self to_others violence from_others escape
-                intolerant_behaviour prohibited_items ].freeze
-  TRANSIT = %i[ disabilities allergies non_association ].freeze
+  GENERAL = %i[ to_self violence from_others escape intolerant_behaviour
+                prohibited_items non_association ].freeze
 
-  [GENERAL, TRANSIT].flatten.each(&method(:text_toggle_attribute))
+  GENERAL.each(&method(:text_toggle_attribute))
 
   def target
     super.risk_information || super.build_risk_information

--- a/app/views/escorts/_risks.html.erb
+++ b/app/views/escorts/_risks.html.erb
@@ -1,7 +1,3 @@
 <% Risks::GENERAL.each do |risk| %>
   <%= render('shared/risk', f: f, risk: risk) %>
 <% end %>
-<h2><%= t('.transit_heading') %></h2>
-<% Risks::TRANSIT.each do |risk| %>
-  <%= render('shared/risk', f: f, risk: risk) %>
-<% end %>

--- a/app/views/pdfs/_risk_summary.html.erb
+++ b/app/views/pdfs/_risk_summary.html.erb
@@ -20,17 +20,6 @@
   </div>
   <div class="risk">
     <div class="description">
-      <div class="title"><strong><%= t('.risks_to_others_public') %></strong>
-      </div>
-      <div class="content"></div>
-    </div>
-    <div class="date">
-      <div class="title"><%= t('.date_of_incident') %></div>
-      <div class="content"></div>
-    </div>
-  </div>
-  <div class="risk">
-    <div class="description">
       <div class="title"><strong><%= t('.violence') %></strong></div>
       <div class="content"></div>
     </div>

--- a/config/locales/pdf.en.yml
+++ b/config/locales/pdf.en.yml
@@ -20,7 +20,7 @@ en:
       risks:
         title: Risks overview
         notes: Section A2 Risk summary
-        violence: Violence
+        violence: Violence and risk to others
         escape: Escort escape risk
         allergies: Allergies
         disabilities: Disabilities
@@ -46,19 +46,18 @@ en:
       nationality: :'shared.nationality'
       cro_number: :'shared.cro_number'
       pnc_number: :'shared.pnc_number'
-    updates: 
+    updates:
       title: Risk updates
       instructions: Include relevant updates and heightened risks from section B3
       sash_instructions: Tick if SASH has been opened
     risk_summary:
       heading: A2. Risk summary
       risks_to_self: Risks to self
-      risks_to_others_public: Risks to others / risks to public
       date_of_incident: Date of incident
-      violence: Violence
+      violence: Violence and risk to others
       risk_from_others: Risk from others
       escort_escape_risk: Escort escape risk
-      intolerant_behaviour: Intolerant behaviour
+      intolerant_behaviour: Intolerant behaviour towards others
       prohibited_items: Prohibited items
       non_association: Non-association
       completed_by: Name of person filling in this section

--- a/config/locales/risks.en.yml
+++ b/config/locales/risks.en.yml
@@ -8,43 +8,31 @@ en:
       types:
         to_self:
           title: Risks to self
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
-        to_others:
-          title: Risks to others
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
+          help_text: Is there a risk of suicide or self-harm?
+          details_help_text: Give details of open or recently closed ACCTs, indicative behaviours or threats, offence type or recall status. Include known dates and triggers.
         violence:
-          title: Violence
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
+          title: Violence and risk to others
+          help_text: Is there a history of violence towards others?
+          details_help_text: Give details of actual or threatened violence - include victim age, gender, ethnic group, or prisoner or staff group. Include known dates and triggers.
         from_others:
           title: Risk from others
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
+          help_text: Is there a risk from others?
+          details_help_text: Give details of type of harm, whether verbal or physical and offence detail that may put them at risk of harm. Include known dates and triggers.
         escape:
           title: Escort escape risk
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
+          help_text: Is there an escape risk?
+          details_help_text: Give details of whether the prisoner is on the prison E list, or any intelligence that suggests an escape risk. Include known dates and triggers.
         intolerant_behaviour:
-          title: Intolerant behavior
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
+          title: Intolerant behavior towards others
+          help_text: Is there a history of intolerant behaviour towards others, such as sexism, homophobia or racism?
+          details_help_text: Give details of any incidents or threats, or offence related indicators. Include known dates and triggers.
         prohibited_items:
           title: Prohibited items
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
-        disabilities:
-          title: Disabilities
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
-        allergies:
-          title: Allergies
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
+          help_text: Is there a history of carrying concealed weapons or prohibited items?
+          details_help_text: Give details of any intelligence or a history of smuggling weapons, drugs or other prohibited items. Include known dates and triggers.
         non_association:
           title: Non-association
-          help_text: Help copy lorem ipsum dolor
-          details_help_text: Give the details of risk, including incidents, behaviour and triggers
+          help_text: Are there any non-association markers?
+          details_help_text: Give details of other prisoners (names & prison numbers), and details of the reasons for non-association, i.e. gang affiliations. Include known dates and triggers.
       labels:
         clear: Clear selection

--- a/db/migrate/20160301144518_remove_fields_from_risk_information.rb
+++ b/db/migrate/20160301144518_remove_fields_from_risk_information.rb
@@ -1,0 +1,10 @@
+class RemoveFieldsFromRiskInformation < ActiveRecord::Migration
+  def change
+    remove_column :risk_information, :to_others, :boolean
+    remove_column :risk_information, :to_others_details, :text
+    remove_column :risk_information, :disabilities, :boolean
+    remove_column :risk_information, :disabilities_details, :text
+    remove_column :risk_information, :allergies, :boolean
+    remove_column :risk_information, :allergies_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160224131149) do
+ActiveRecord::Schema.define(version: 20160301144518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,8 +40,6 @@ ActiveRecord::Schema.define(version: 20160224131149) do
     t.uuid     "escort_id"
     t.boolean  "to_self"
     t.text     "to_self_details"
-    t.boolean  "to_others"
-    t.text     "to_others_details"
     t.boolean  "violence"
     t.text     "violence_details"
     t.boolean  "from_others"
@@ -52,10 +50,6 @@ ActiveRecord::Schema.define(version: 20160224131149) do
     t.text     "intolerant_behaviour_details"
     t.boolean  "prohibited_items"
     t.text     "prohibited_items_details"
-    t.boolean  "disabilities"
-    t.text     "disabilities_details"
-    t.boolean  "allergies"
-    t.text     "allergies_details"
     t.boolean  "non_association"
     t.text     "non_association_details"
     t.datetime "created_at",                   null: false

--- a/spec/forms/risks_spec.rb
+++ b/spec/forms/risks_spec.rb
@@ -1,19 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Risks, type: :form do
-  general_risks = %i[ to_self to_others violence from_others
-                      escape intolerant_behaviour prohibited_items ]
-  transit_risks = %i[ disabilities allergies non_association ]
+  general_risks = %i[ to_self violence from_others escape
+                      intolerant_behaviour prohibited_items non_association ]
 
   describe '::GENERAL' do
     specify do
       expect(described_class::GENERAL).to match_array general_risks
-    end
-  end
-
-  describe '::TRANSIT' do
-    specify do
-      expect(described_class::TRANSIT).to match_array transit_risks
     end
   end
 
@@ -22,11 +15,9 @@ RSpec.describe Risks, type: :form do
   input_attributes = {
     to_self: 'true',
     to_self_details: 'some text',
-    to_others: 'false',
-    to_others_details: 'some text',
-    violence: 'unknown',
+    violence: 'false',
     violence_details: 'some text',
-    from_others: 'true',
+    from_others: 'unknown',
     from_others_details: 'some text',
     escape: 'true',
     escape_details: 'some text',
@@ -34,26 +25,19 @@ RSpec.describe Risks, type: :form do
     intolerant_behaviour_details: 'some text',
     prohibited_items: 'true',
     prohibited_items_details: 'some text',
-    disabilities: 'true',
-    disabilities_details: 'some text',
-    allergies: 'true',
-    allergies_details: 'some text',
     non_association: 'true',
     non_association_details: 'some text'
   }
 
   coercion_overrides = {
     to_self: true,
-    to_others: false,
-    to_others_details: nil,
-    violence: nil,
+    violence: false,
     violence_details: nil,
-    from_others: true,
+    from_others: nil,
+    from_others_details: nil,
     escape: true,
     intolerant_behaviour: true,
     prohibited_items: true,
-    disabilities: true,
-    allergies: true,
     non_association: true
   }
 
@@ -62,6 +46,5 @@ RSpec.describe Risks, type: :form do
   it_behaves_like 'a form that retrives or builds its target', :risk_information
   it_behaves_like 'a form that knows what template to render', 'risks'
   it_behaves_like 'a form that belongs to an endpoint', 'risks'
-  it_behaves_like 'a form with a text toggle attribute',
-    general_risks, transit_risks
+  it_behaves_like 'a form with a text toggle attribute', general_risks
 end

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -54,11 +54,10 @@ RSpec.describe PdfGenerator, type: :service do
       expect(html).to have_content('A2. Risk summary').
         and have_content('PNC / Prison number').
         and have_content('Risks to self').
-        and have_content('Risks to others / risks to public').
-        and have_content('Violence').
+        and have_content('Violence and risk to others').
         and have_content('Risk from others').
         and have_content('Escort escape risk').
-        and have_content('Intolerant behaviour').
+        and have_content('Intolerant behaviour towards others').
         and have_content('Prohibited items').
         and have_content('Non-association').
         and have_content('Date of incident').

--- a/spec/support/feature_helpers/risks_form.rb
+++ b/spec/support/feature_helpers/risks_form.rb
@@ -20,9 +20,9 @@ module FeatureHelpers
     end
 
     def build_risk_properties
-      ['Risks to self', 'Risks to others', 'Violence', 'Risk from others',
-       'Escort escape risk', 'Intolerant behavior', 'Prohibited items',
-       'Disabilities', 'Allergies', 'Non-association'
+      ['Risks to self', 'Violence and risk to others', 'Risk from others',
+       'Escort escape risk', 'Intolerant behavior towards others',
+       'Prohibited items', 'Non-association'
       ].each_with_index.
         each_with_object({}) do |(r, i), o|
         o[r] = (i.odd? ? ['Yes', 'Some user input'] : ['No', nil])


### PR DESCRIPTION
Removed risks_to_others, disabilities and allergies 
fields from risk information model, form and PDF.

Renamed Violence to Violence and risk to others.

Renamed Intolerant behaviour to Intolerant behaviour 
towards others.

Filled in help_text and details_help_text copy text 
on risks form.
