### PR TITLE
Move information form

### DIFF
--- a/app/assets/stylesheets/_summary.scss
+++ b/app/assets/stylesheets/_summary.scss
@@ -51,5 +51,17 @@
     .pnc-number {
       @include grid-column(1/4)
     }
+    .origin {
+      @include grid-column(1/4)
+    }
+    .destination {
+      @include grid-column(1/4)
+    }
+    .date_of_travel {
+      @include grid-column(1/4)
+    }
+    .reason {
+      @include grid-column(3/4)
+    }
   }
 }

--- a/app/controllers/escorts_controller.rb
+++ b/app/controllers/escorts_controller.rb
@@ -23,7 +23,7 @@ class EscortsController < ApplicationController
 private
 
   def form
-    @form ||= current_page.capitalize.constantize.new(escort)
+    @form ||= current_page.camelcase.constantize.new(escort)
   end
 
   def persist_form_data

--- a/app/forms/form/core.rb
+++ b/app/forms/form/core.rb
@@ -8,7 +8,7 @@ class Form
       include ActiveModel::Validations
 
       def name
-        self.class.name.downcase
+        self.class.name.underscore.downcase
       end
       alias_method :template, :name
     end

--- a/app/forms/form/routing.rb
+++ b/app/forms/form/routing.rb
@@ -1,0 +1,21 @@
+class Form
+  module Routing
+    FORM_NAMES = %i[ identification risks move_information ]
+
+    FormData = Struct.new(:name) do
+      def path
+        name.to_s.dasherize
+      end
+    end
+
+  module_function
+
+    def resource_list
+      form_names.map { |name| FormData.new(name) }
+    end
+
+    def form_names
+      FORM_NAMES
+    end
+  end
+end

--- a/app/forms/move_information.rb
+++ b/app/forms/move_information.rb
@@ -6,6 +6,10 @@ class MoveInformation < Form
   attribute :reason,      String
   date :date_of_travel
 
+  validates :date_of_travel,
+    inclusion: { in: ->(*) { Date.today..Date::Infinity.new } },
+    allow_blank: true
+
   def formatted_date_today
     Date.today.strftime('%d %m %Y')
   end

--- a/app/forms/move_information.rb
+++ b/app/forms/move_information.rb
@@ -1,0 +1,16 @@
+class MoveInformation < Form
+  include Form::DateHandling
+
+  attribute :origin,      String
+  attribute :destination, String
+  attribute :reason,      String
+  date :date_of_travel
+
+  def formatted_date_today
+    Date.today.strftime('%d %m %Y')
+  end
+
+  def target
+    super.move
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,28 +5,4 @@ module ApplicationHelper
     end
     content_tag(:div, class: styles) { yield }
   end
-
-  def navigation_item(text, path)
-    content_tag(:li, link_or_text(text, path), class: apply_current_class(path))
-  end
-
-  def apply_current_class(path)
-    'current' if current_page?(path)
-  end
-
-  def link_or_text(text, path)
-    current_page?(path) ? text : link_to(text, path)
-  end
-
-  def current_page?(path)
-    path == request.env['PATH_INFO']
-  end
-
-  SECTIONS = %w[ summary identification risks move_information ]
-
-  def navigation_list
-    SECTIONS.each_with_object(ActiveSupport::SafeBuffer.new) do |name, buf|
-      buf << navigation_item(t("navigation.#{name}"), send("#{name}_path"))
-    end
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
     path == request.env['PATH_INFO']
   end
 
-  SECTIONS = %w[ summary identification risks ]
+  SECTIONS = %w[ summary identification risks move_information ]
 
   def navigation_list
     SECTIONS.each_with_object(ActiveSupport::SafeBuffer.new) do |name, buf|

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,0 +1,25 @@
+module NavigationHelper
+  def navigation_item(text, path)
+    content_tag(:li, link_or_text(text, path), class: apply_current_class(path))
+  end
+
+  def apply_current_class(path)
+    'current' if current_page?(path)
+  end
+
+  def link_or_text(text, path)
+    current_page?(path) ? text : link_to(text, path)
+  end
+
+  def current_page?(path)
+    path == request.env['PATH_INFO']
+  end
+
+  SECTIONS = ['summary', Form::Routing.form_names].flatten
+
+  def navigation_list
+    SECTIONS.each_with_object(ActiveSupport::SafeBuffer.new) do |name, buf|
+      buf << navigation_item(t("navigation.#{name}"), send("#{name}_path"))
+    end
+  end
+end

--- a/app/models/escort.rb
+++ b/app/models/escort.rb
@@ -2,6 +2,7 @@ class Escort < ActiveRecord::Base
   has_paper_trail
   has_one :prisoner
   has_one :risk_information
+  has_one :move
 
   def self.find_by_prison_number(prison_number)
     joins(:prisoner).
@@ -22,5 +23,9 @@ class Escort < ActiveRecord::Base
 
   def risk_information
     super || build_risk_information
+  end
+
+  def move
+    super || build_move
   end
 end

--- a/app/models/escort.rb
+++ b/app/models/escort.rb
@@ -26,6 +26,6 @@ class Escort < ActiveRecord::Base
   end
 
   def move
-    super || build_move
+    super || build_move(Move.default_origin_option)
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,4 +1,8 @@
 class Move < ActiveRecord::Base
   has_paper_trail
   belongs_to :escort, touch: true
+
+  def self.default_origin_option
+    { origin: I18n.t('escorts.move_information.default_origin') }
+  end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,0 +1,4 @@
+class Move < ActiveRecord::Base
+  has_paper_trail
+  belongs_to :escort, touch: true
+end

--- a/app/presenters/move_presenter.rb
+++ b/app/presenters/move_presenter.rb
@@ -1,0 +1,19 @@
+class MovePresenter
+  def initialize(model)
+    @model = model
+  end
+
+  delegate :origin, :destination, :date_of_travel, :reason, to: :@model
+
+  private :date_of_travel
+
+  def edit_section_path
+    Rails.application.routes.url_helpers.move_information_path(@model.escort)
+  end
+
+  def formatted_date_of_travel
+    if date_of_travel.present?
+      date_of_travel.strftime('%d/%m/%Y')
+    end
+  end
+end

--- a/app/presenters/pdf/escort_presenter.rb
+++ b/app/presenters/pdf/escort_presenter.rb
@@ -7,5 +7,9 @@ module Pdf
     def prisoner
       @prisoner ||= Pdf::PrisonerPresenter.new(@escort.prisoner)
     end
+
+    def move
+      @move ||= Pdf::MovePresenter.new(@escort.move)
+    end
   end
 end

--- a/app/presenters/pdf/move_presenter.rb
+++ b/app/presenters/pdf/move_presenter.rb
@@ -1,0 +1,13 @@
+module Pdf
+  class MovePresenter
+    def initialize(model)
+      @model = model
+    end
+
+    delegate :origin, :destination, :date_of_travel, :reason, to: :@model
+    private :date_of_travel
+
+    delegate :day, :month, :year,
+      to: :date_of_travel, prefix: true, allow_nil: true
+  end
+end

--- a/app/presenters/summary_presenter.rb
+++ b/app/presenters/summary_presenter.rb
@@ -6,4 +6,8 @@ class SummaryPresenter
   def prisoner
     @prisoner ||= PrisonerPresenter.new(@escort.prisoner)
   end
+
+  def move
+    @move ||= MovePresenter.new(@escort.move)
+  end
 end

--- a/app/views/escorts/_move_information.html.erb
+++ b/app/views/escorts/_move_information.html.erb
@@ -1,0 +1,61 @@
+<div class="form-group">
+  <%= f.label :origin, class: 'form-label-bold' %>
+  <%= f.text_field :origin, class: 'string form-control'%>
+</div>
+
+<div class="form-group">
+  <%= f.label :destination, class: 'form-label-bold' %>
+  <%= f.text_field :destination, class: 'string form-control' %>
+</div>
+
+<div class="form-date">
+  <fieldset>
+    <legend class="form-label-bold">
+      <%= t('.date_of_travel.label') %>
+    </legend>
+    <p class="form-hint datefield-hint">
+      <%= t('.date_of_travel.hint', today: f.object.formatted_date_today ) %>
+    </p>
+    <div class="form-group form-group-day">
+      <label for="move_information_date_of_travel_day">
+        <%= t('.date_of_travel.day_label') %>
+      </label>
+      <%= text_field_tag(
+              'move_information[date_of_travel][day]',
+              f.object.date_of_travel_presenter.day,
+              maxlength: 2,
+              size: 2,
+              class: 'form-control'
+          ) %>
+    </div>
+    <div class="form-group form-group-month">
+      <label for="move_information_date_of_travel_month">
+        <%= t('.date_of_travel.month_label') %>
+      </label>
+      <%= text_field_tag(
+              'move_information[date_of_travel][month]',
+              f.object.date_of_travel_presenter.month,
+              maxlength: 2,
+              size: 2,
+              class: 'form-control'
+          ) %>
+    </div>
+    <div class="form-group form-group-year">
+      <label for="move_information_date_of_travel_year">
+        <%= t('.date_of_travel.year_label') %>
+      </label>
+      <%= text_field_tag(
+              'move_information[date_of_travel][year]',
+              f.object.date_of_travel_presenter.year,
+              maxlength: 4,
+              size: 4,
+              class: 'form-control'
+          ) %>
+    </div>
+  </fieldset>
+</div>
+
+<div class="form-group">
+  <%= f.label :reason, class: 'form-label-bold' %>
+  <%= f.text_field :reason, class: 'string form-control' %>
+</div>

--- a/app/views/escorts/summary.html.erb
+++ b/app/views/escorts/summary.html.erb
@@ -8,5 +8,6 @@
       <h1><%= t(".heading") %></h1>
     </header>
     <%= render('escorts/summary/prisoner', prisoner: @summary.prisoner) %>
+    <%= render('escorts/summary/move', move: @summary.move) %>
   </div>
 </div>

--- a/app/views/escorts/summary/_move.html.erb
+++ b/app/views/escorts/summary/_move.html.erb
@@ -1,0 +1,26 @@
+<div class="summary-heading">
+  <h2><%= t('.heading') %></h2>
+  <%= link_to t('.edit_section'), move.edit_section_path %>
+</div>
+<div class="summary-content">
+  <div>
+    <div class="origin">
+      <strong class="label"><%= t('.origin') %></strong>
+      <div class="output"><%= move.origin %></div>
+    </div>
+    <div class="destination">
+      <strong class="label"><%= t('.destination') %></strong>
+      <div class="output"><%= move.destination %></div>
+    </div>
+    <div class="date_of_travel">
+      <strong class="label"><%= t('.date_of_travel') %></strong>
+      <div class="output"><%= move.formatted_date_of_travel %></div>
+    </div>
+  </div>
+  <div>
+    <div class="reason">
+      <strong class="label"><%= t('.reason') %></strong>
+      <div class="output"><%= move.reason %></div>
+    </div>
+  </div>
+</div>

--- a/app/views/pdfs/_move_information.html.erb
+++ b/app/views/pdfs/_move_information.html.erb
@@ -1,17 +1,17 @@
 <div class="move-information">
   <div class="from">
     <strong class="label"><%= t('.from') %></strong>
-    <div class="input"></div>
+    <div class="input"><%= move.origin %></div>
   </div>
   <div class="to">
     <strong class="label"><%= t('.to') %></strong>
-    <div class="input"></div>
+    <div class="input"><%= move.destination %></div>
   </div>
   <div class="date-of-travel">
       <strong class="label"><%= t('.date') %></strong>
-      <div class="input"></div>
-      <div class="input"></div>
-      <div class="input"></div>
+      <div class="input"><%= move.date_of_travel_day %></div>
+      <div class="input"><%= move.date_of_travel_month %></div>
+      <div class="input"><%= move.date_of_travel_year %></div>
   </div>
   <div class="destination-update">
     <strong class="label"><%= t('.destination_update') %></strong>
@@ -21,6 +21,6 @@
 <div class="move-information">
   <div class="reason-for-move">
     <strong class="label"><%= t('.reason_for_move') %></strong>
-    <div class="input"></div>
+    <div class="input"><%= move.reason %></div>
   </div>
 </div>

--- a/app/views/pdfs/_prisoner.html.erb
+++ b/app/views/pdfs/_prisoner.html.erb
@@ -1,4 +1,3 @@
-
 <article class="prisoner-information">
   <div>
     <div class="information">

--- a/app/views/pdfs/show.html.erb
+++ b/app/views/pdfs/show.html.erb
@@ -11,7 +11,7 @@
 <body>
 <%= render('pdfs/header') %>
 <%= render('pdfs/not_for_release') %>
-<%= render('pdfs/move_information') %>
+<%= render('pdfs/move_information', move: escort.move) %>
 <%= render('pdfs/prisoner', prisoner: escort.prisoner) %>
 <%= render('pdfs/front_page_markers') %>
 <%= render('pdfs/updates') %>

--- a/config/locales/_shared.en.yml
+++ b/config/locales/_shared.en.yml
@@ -3,14 +3,17 @@ en:
     age: Age
     cro_number: CRO number
     date_of_birth: Date of birth
+    day_label: Day
     family_name: Family name
     forenames: Forenames
+    medication: Medication
+    month_label: Month
+    name: Name (print)
     nationality: Nationality
     pnc_number: PNC number
     prison_number: Prison number
     prisoner_information_heading: Prisoner Information
-    sex: Sex
     reason: Reason
-    medication: Medication
-    name: Name (print)
+    sex: Sex
     signature: Signature
+    year_label: Year

--- a/config/locales/_shared.en.yml
+++ b/config/locales/_shared.en.yml
@@ -3,13 +3,18 @@ en:
     age: Age
     cro_number: CRO number
     date_of_birth: Date of birth
+    date_of_travel: Date of travel
     day_label: Day
+    destination: To
+    edit_section_link_text: Edit
     family_name: Family name
     forenames: Forenames
     medication: Medication
     month_label: Month
+    move_information_heading: Move Information
     name: Name (print)
     nationality: Nationality
+    origin: From
     pnc_number: PNC number
     prison_number: Prison number
     prisoner_information_heading: Prisoner Information

--- a/config/locales/move_information.en.yml
+++ b/config/locales/move_information.en.yml
@@ -21,4 +21,5 @@ en:
         move_information:
           attributes:
             date_of_travel:
-              invalid: invalid date of tarvel
+              invalid: invalid date of travel
+              inclusion: cannot be in the past

--- a/config/locales/move_information.en.yml
+++ b/config/locales/move_information.en.yml
@@ -1,0 +1,24 @@
+en:
+  helpers:
+    label:
+      move_information:
+        origin: From
+        destination: To
+        reason: Reason for move(current offence)
+  escorts:
+    move_information:
+      heading: Move Information
+      default_origin: HMP Bedford
+      date_of_travel:
+        label: Date of travel
+        hint: eg, %{today}
+        day_label: :'shared.day_label'
+        month_label: :'shared.month_label'
+        year_label: :'shared.year_label'
+  activemodel:
+    errors:
+      models:
+        move_information:
+          attributes:
+            date_of_travel:
+              invalid: invalid date of tarvel

--- a/config/locales/move_information.en.yml
+++ b/config/locales/move_information.en.yml
@@ -2,15 +2,15 @@ en:
   helpers:
     label:
       move_information:
-        origin: From
-        destination: To
+        origin: :'shared.origin'
+        destination: :'shared.destination'
         reason: Reason for move(current offence)
   escorts:
     move_information:
-      heading: Move Information
+      heading: :'shared.move_information_heading'
       default_origin: HMP Bedford
       date_of_travel:
-        label: Date of travel
+        label: :'shared.date_of_travel'
         hint: eg, %{today}
         day_label: :'shared.day_label'
         month_label: :'shared.month_label'

--- a/config/locales/navigation.en.yml
+++ b/config/locales/navigation.en.yml
@@ -4,6 +4,7 @@ en:
     identification: Identification
     summary: Summary
     risks: Risks
+    move_information: Move Information
   quick_actions:
     heading: Quick actions
     preview: Preview PER

--- a/config/locales/summary.en.yml
+++ b/config/locales/summary.en.yml
@@ -4,7 +4,7 @@ en:
       heading: Summary
       prisoner:
         heading: :'shared.prisoner_information_heading'
-        edit_section: Edit
+        edit_section: :'shared.edit_section_link_text'
         family_name: :'shared.family_name'
         forenames: :'shared.forenames'
         date_of_birth: :'shared.date_of_birth'
@@ -14,3 +14,10 @@ en:
         nationality: :'shared.nationality'
         cro_number: :'shared.cro_number'
         pnc_number: :'shared.pnc_number'
+      move:
+        heading: :'shared.move_information_heading'
+        edit_section: :'shared.edit_section_link_text'
+        origin: :'shared.origin'
+        destination: :'shared.destination'
+        date_of_travel: :'shared.date_of_travel'
+        reason: Reason for move

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,27 +2,20 @@ Rails.application.routes.draw do
   devise_for :users, skip: %i[ registrations ]
 
   scope 'escort/:id' do
-    resource :identification,
-      only: %i[ show update ],
-      controller: :escorts,
-      page: :identification
-
-    resource :risks,
-      only: %i[ show update ],
-      controller: :escorts,
-      page: :risks
-
-    resource :move_information,
-      only: %i[ show update ],
-      controller: :escorts,
-      path: 'move-information',
-      page: :move_information
+    Form::Routing.resource_list.each do |r|
+      resource r.name,
+        only: %i[ show update], controller: :escorts,
+        path: r.path, page: r.name
+    end
 
     get 'summary', controller: :escorts
 
     resource :pdf, only: :show
   end
+
   resource :escort, only: :create
+
   post 'search', controller: :home_pages
+
   root to: 'home_pages#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,11 +6,20 @@ Rails.application.routes.draw do
       only: %i[ show update ],
       controller: :escorts,
       page: :identification
+
     resource :risks,
       only: %i[ show update ],
       controller: :escorts,
       page: :risks
+
+    resource :move_information,
+      only: %i[ show update ],
+      controller: :escorts,
+      path: 'move-information',
+      page: :move_information
+
     get 'summary', controller: :escorts
+
     resource :pdf, only: :show
   end
   resource :escort, only: :create

--- a/db/migrate/20160302163946_create_moves.rb
+++ b/db/migrate/20160302163946_create_moves.rb
@@ -1,0 +1,13 @@
+class CreateMoves < ActiveRecord::Migration
+  def change
+    create_table :moves, id: :uuid, default: "uuid_generate_v4()" do |t|
+      t.uuid   :escort_id
+      t.string :origin
+      t.string :destination
+      t.date :date_of_travel
+      t.string :reason
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301144518) do
+ActiveRecord::Schema.define(version: 20160302163946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,16 @@ ActiveRecord::Schema.define(version: 20160301144518) do
   create_table "escorts", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "moves", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.uuid     "escort_id"
+    t.string   "origin"
+    t.string   "destination"
+    t.date     "date_of_travel"
+    t.string   "reason"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
   end
 
   create_table "prisoners", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,6 +15,12 @@ FactoryGirl.define do
         create :risk_information, escort: escort
       end
     end
+
+    trait :with_move do
+      after :create do |escort|
+        create :move, escort: escort
+      end
+    end
   end
 
   factory :prisoner do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,7 +56,7 @@ FactoryGirl.define do
   factory :move do
     origin 'HMP Clive House'
     destination 'Petty France'
-    date_of_travel { Date.tomorrow }
+    date_of_travel { Date.today }
     reason 'Expected to attend show the thing'
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,4 +52,11 @@ FactoryGirl.define do
     password 'secret123'
     password_confirmation 'secret123'
   end
+
+  factory :move do
+    origin 'HMP Clive House'
+    destination 'Petty France'
+    date_of_travel { Date.tomorrow }
+    reason 'Expected to attend show the thing'
+  end
 end

--- a/spec/features/completing_escort_spec.rb
+++ b/spec/features/completing_escort_spec.rb
@@ -58,6 +58,8 @@ RSpec.feature 'completing digital person escort record', type: :feature do
     fill_in_identification
     click_link 'Risks'
     fill_in_risks
+    click_link 'Move Information'
+    fill_in_move_information
     click_link 'Summary'
 
     expect(page).to have_heading 'Summary'
@@ -73,5 +75,12 @@ RSpec.feature 'completing digital person escort record', type: :feature do
       and have_content('Prison number A1234BC').
       and have_content('CRO number SOMECRO').
       and have_content('PNC number SOMEPNC')
+
+    expect(page).to have_text('Summary').
+      and have_link('Edit', href: move_information_path(escort)).
+      and have_content('From HMP Clive House').
+      and have_content('To Petty France').
+      and have_content('Date of travel 03/02/2015').
+      and have_content('Reason for move Expected to attend show the thing')
   end
 end

--- a/spec/features/completing_escort_spec.rb
+++ b/spec/features/completing_escort_spec.rb
@@ -40,6 +40,19 @@ RSpec.feature 'completing digital person escort record', type: :feature do
       to have_content 'Escort record updated successfully'
   end
 
+  scenario 'filling in the move information page' do
+    start_escort_form
+    fill_in_identification
+    click_link 'Move Information'
+
+    expect(page).to have_heading 'Move Information'
+
+    fill_in_move_information
+
+    expect(page).
+      to have_content 'Escort record updated successfully'
+  end
+
   scenario 'vieiwing the summary of an escort' do
     start_escort_form
     fill_in_identification

--- a/spec/forms/form/routing_spec.rb
+++ b/spec/forms/form/routing_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Form::Routing, type: :form do
+  describe '.resource_list' do
+    it 'returns a list of objects that respond to name' do
+      expect(described_class.resource_list.map(&:name)).
+        to match_array %i[ identification risks move_information ]
+    end
+
+    it 'returns a list of objects that respond to path' do
+      expect(described_class.resource_list.map(&:path)).
+        to match_array %w[ identification risks move-information ]
+    end
+  end
+
+  describe '.form_names' do
+    it 'returns an array of symbolized form names' do
+      expect(described_class.form_names).
+        to match_array %i[ identification risks move_information ]
+    end
+  end
+end

--- a/spec/forms/move_information_spec.rb
+++ b/spec/forms/move_information_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe MoveInformation, type: :form do
+  let(:escort) { create(:escort) }
+
+  subject { described_class.new(escort) }
+
+  input_attributes = {
+    origin: 'HMP Clive House',
+    destination: 'Petty France',
+    date_of_travel: { day: '23', month: '2', year: '2016' },
+    reason: 'Expected to attend show the thing'
+  }
+  coercion_overrides = { date_of_travel: Date.civil(2016, 2, 23) }
+  it_behaves_like 'a form that syncs to a model',
+    input_attributes, coercion_overrides
+
+  it_behaves_like 'a form that retrives or builds its target', :move
+
+  it_behaves_like 'a form that knows what template to render',
+    'move_information'
+
+  it_behaves_like 'a form that belongs to an endpoint',
+    'move-information'
+
+  it_behaves_like 'a form with dates', %i[ date_of_travel ]
+
+  describe '#formatted_date_today' do
+    it 'returns the current date in the format "DD MM YYYY"' do
+      travel_to(Date.civil(2016, 2, 23)) do
+        expect(subject.formatted_date_today).to eq '23 02 2016'
+      end
+    end
+  end
+end

--- a/spec/forms/move_information_spec.rb
+++ b/spec/forms/move_information_spec.rb
@@ -32,4 +32,33 @@ RSpec.describe MoveInformation, type: :form do
       end
     end
   end
+
+  describe 'validations' do
+    describe 'date_of_travel' do
+      it 'allows blank dates' do
+        subject.date_of_travel = nil
+        subject.validate
+        is_expected.not_to have_error_for(:date_of_travel)
+      end
+
+      it 'allows todays date' do
+        subject.date_of_travel = Date.today
+        subject.validate
+        is_expected.not_to have_error_for(:date_of_travel)
+      end
+
+      it 'allows dates in the future' do
+        subject.date_of_travel = Date.tomorrow
+        subject.validate
+        is_expected.not_to have_error_for(:date_of_travel)
+      end
+
+      it 'does not allow dates in the past' do
+        subject.date_of_travel = Date.yesterday
+        subject.validate
+        is_expected.to have_error_for(:date_of_travel).
+          with_message(/in the past/)
+      end
+    end
+  end
 end

--- a/spec/models/escort_spec.rb
+++ b/spec/models/escort_spec.rb
@@ -50,13 +50,13 @@ RSpec.describe Escort, type: :model do
   end
 
   describe '#prisoner' do
-    context 'with prisoner' do
+    context 'when a prisoner exists' do
       subject { create(:escort, :with_prisoner) }
       its(:prisoner) { is_expected.to be_persisted }
       its(:prisoner) { is_expected.to be_kind_of(Prisoner) }
     end
 
-    context 'without prisoner' do
+    context 'when a prisoner does not exist' do
       subject { create(:escort) }
       its(:prisoner) { is_expected.to_not be_persisted }
       its(:prisoner) { is_expected.to be_kind_of(Prisoner) }
@@ -64,16 +64,34 @@ RSpec.describe Escort, type: :model do
   end
 
   describe '#risk_information' do
-    context 'with risk_information' do
+    context 'when risk_information exists' do
       subject { create(:escort, :with_risk_information) }
       its(:risk_information) { is_expected.to be_persisted }
       its(:risk_information) { is_expected.to be_kind_of(RiskInformation) }
     end
 
-    context 'without risk_information' do
+    context 'when risk_information does not exist' do
       subject { create(:escort) }
       its(:risk_information) { is_expected.to_not be_persisted }
       its(:risk_information) { is_expected.to be_kind_of(RiskInformation) }
+    end
+  end
+
+  describe '#move' do
+    context 'when a move exists' do
+      subject { create(:escort, :with_move) }
+      its(:move) { is_expected.to be_persisted }
+      its(:move) { is_expected.to be_kind_of(Move) }
+    end
+
+    context 'when a move does not exist' do
+      subject { create(:escort) }
+      its(:move) { is_expected.not_to be_persisted }
+      its(:move) { is_expected.to be_kind_of(Move) }
+
+      it 'has a default origin set' do
+        expect(subject.move.origin).to eq 'HMP Bedford'
+      end
     end
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Move, type: :model do
+  it_behaves_like 'an auditable record'
+  it_behaves_like 'a record with a uuid as a primary key'
+  it_behaves_like 'a record that updates the escort on save'
+end

--- a/spec/presenters/move_presenter_spec.rb
+++ b/spec/presenters/move_presenter_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe MovePresenter, type: :presenter do
+  let(:escort) { create(:escort) }
+  let(:move) { escort.move }
+
+  subject { described_class.new(move) }
+
+  describe '#edit_section_link' do
+    it 'returns a path to the identification form page' do
+      expected_link_path = "/escort/#{escort.id}/move-information"
+      expect(subject.edit_section_path).to eq expected_link_path
+    end
+  end
+
+  %i[ origin destination reason ].each do |method|
+    it "delegates #{method} to the move model" do
+      expect(move).to receive(method)
+      subject.public_send(method)
+    end
+  end
+
+  describe '#formatted_date_of_travel' do
+    context 'when date_of_travel is present' do
+      it 'returns a date in the format DD/MM/YYYY' do
+        move.date_of_travel = Date.civil(2016, 10, 23)
+        expect(subject.formatted_date_of_travel).to eq '23/10/2016'
+      end
+    end
+
+    context 'when date_of_travel is not present' do
+      it 'returns nil' do
+        move.date_of_travel = nil
+        expect(subject.formatted_date_of_travel).to be_nil
+      end
+    end
+  end
+end

--- a/spec/presenters/pdf/escort_presenter_spec.rb
+++ b/spec/presenters/pdf/escort_presenter_spec.rb
@@ -5,4 +5,6 @@ RSpec.describe Pdf::EscortPresenter, type: :presenter do
   subject { described_class.new(escort) }
 
   its(:prisoner) { is_expected.to be_kind_of Pdf::PrisonerPresenter }
+
+  its(:move) { is_expected.to be_kind_of Pdf::MovePresenter }
 end

--- a/spec/presenters/pdf/move_presenter_spec.rb
+++ b/spec/presenters/pdf/move_presenter_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Pdf::MovePresenter, type: :presenter do
+  let(:escort) { create(:escort) }
+  let(:move) { escort.move }
+
+  subject { described_class.new(move) }
+
+  %i[ origin destination reason ].each do |method|
+    it "delegates #{method} to the move model" do
+      expect(move).to receive(method)
+      subject.public_send(method)
+    end
+  end
+
+  %i[ day month year ].each do |method|
+    it do
+      is_expected.to delegate_method(method).to(:date_of_travel).with_prefix
+    end
+  end
+end

--- a/spec/presenters/summary_presenter_spec.rb
+++ b/spec/presenters/summary_presenter_spec.rb
@@ -5,4 +5,6 @@ RSpec.describe SummaryPresenter, type: :presenter do
   subject { described_class.new(escort) }
 
   its(:prisoner) { is_expected.to be_kind_of PrisonerPresenter }
+
+  its(:move) { is_expected.to be_kind_of MovePresenter }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,7 @@ RSpec.configure do |config|
   config.include(FeatureHelpers::Sessions, type: :feature)
   config.include(FeatureHelpers::IdentificationForm, type: :feature)
   config.include(FeatureHelpers::RisksForm, type: :feature)
+  config.include(FeatureHelpers::MoveInformationForm, type: :feature)
   config.include(MailHelpers)
   config.include(Shoulda::Matchers::ActiveModel, type: :form)
   config.include(FactoryGirl::Syntax::Methods)

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe PdfGenerator, type: :service do
     before(:all) do
       travel_to(Date.new(2015, 2, 3)) do
         prisoner = build_stubbed(:prisoner)
-        escort = build_stubbed(:escort, prisoner: prisoner)
+        move = build_stubbed(:move)
+        escort = build_stubbed(:escort, prisoner: prisoner, move: move)
         html = described_class.render(escort)
         @content = ActionController::Base.helpers.strip_tags(html)
       end
@@ -38,10 +39,12 @@ RSpec.describe PdfGenerator, type: :service do
     end
 
     it 'generates the expected content for move information section' do
-      expect(content).to have_content('From').
-        and have_content('To').
-        and have_content('Date of travel').
-        and have_content('Destination update')
+      expect(content).to have_content('From HMP Clive House').
+        and have_content('To Petty France').
+        and have_content('Date of travel 3 2 2015').
+        and have_content('Destination update').
+        and have_content('Reason for move (current offence) ' \
+          'Expected to attend show the thing')
     end
 
     it 'generates the expected content for personal information section' do

--- a/spec/support/feature_helpers/move_information_form.rb
+++ b/spec/support/feature_helpers/move_information_form.rb
@@ -1,0 +1,19 @@
+module FeatureHelpers
+  module MoveInformationForm
+    def fill_in_move_information
+      attributes = attributes_for(:move)
+
+      fill_in 'From', with: attributes[:origin]
+      fill_in 'To', with: attributes[:destination]
+
+      date = attributes[:date_of_travel]
+      fill_in 'move_information[date_of_travel][day]', with: date.day
+      fill_in 'move_information[date_of_travel][month]', with: date.month
+      fill_in 'move_information[date_of_travel][year]', with: date.year
+
+      fill_in 'Reason for move(current offence)', with: attributes[:reason]
+
+      click_save
+    end
+  end
+end

--- a/spec/support/matchers/have_error_matcher.rb
+++ b/spec/support/matchers/have_error_matcher.rb
@@ -1,0 +1,14 @@
+RSpec::Matchers.define :have_error_for do |attribute|
+  match do |model|
+    model_errors = model.errors[attribute]
+    model_errors.any? && (@msg.blank? || model_errors.grep(@msg).any?)
+  end
+
+  chain :with_message do |msg|
+    @msg = msg
+  end
+
+  failure_message do
+    "expected model to have errors for #{attribute}"
+  end
+end

--- a/spec/support/shared/form_with_dates.rb
+++ b/spec/support/shared/form_with_dates.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples 'a form with dates' do |date_fields|
         its(date_field) { is_expected.to eq Date.civil(1987, 7, 29) }
         its("#{date_field}_presenter") { is_expected.to be_a Date }
         it 'is valid' do
-          expect(subject.errors[date_field]).to be_empty
+          is_expected.not_to have_error_for(date_field).with_message(invalid_date_text)
         end
       end
 
@@ -30,7 +30,7 @@ RSpec.shared_examples 'a form with dates' do |date_fields|
         its(date_field) { is_expected.to be_nil }
         its("#{date_field}_presenter") { is_expected.to be_a UncoercedDate }
         it 'is valid' do
-          expect(subject.errors[date_field]).to be_empty
+          is_expected.not_to have_error_for(date_field).with_message(invalid_date_text)
         end
       end
 
@@ -39,7 +39,7 @@ RSpec.shared_examples 'a form with dates' do |date_fields|
         its(date_field) { is_expected.to be_nil }
         its("#{date_field}_presenter") { is_expected.to be_a UncoercedDate }
         it 'is valid' do
-          expect(subject.errors[date_field]).to be_empty
+          is_expected.not_to have_error_for(date_field).with_message(invalid_date_text)
         end
       end
 
@@ -48,7 +48,7 @@ RSpec.shared_examples 'a form with dates' do |date_fields|
         its(date_field) { is_expected.to eq date_value }
         its("#{date_field}_presenter") { is_expected.to be_a UncoercedDate }
         it 'is invalid' do
-          expect(subject.errors[date_field]).to include invalid_date_text
+          is_expected.to have_error_for(date_field).with_message(invalid_date_text)
         end
       end
 
@@ -57,7 +57,7 @@ RSpec.shared_examples 'a form with dates' do |date_fields|
         its(date_field) { is_expected.to eq date_value }
         its("#{date_field}_presenter") { is_expected.to be_a UncoercedDate }
         it 'is invalid' do
-          expect(subject.errors[date_field]).to include invalid_date_text
+          is_expected.to have_error_for(date_field).with_message(invalid_date_text)
         end
       end
 
@@ -66,7 +66,7 @@ RSpec.shared_examples 'a form with dates' do |date_fields|
         its(date_field) { is_expected.to eq Date.civil(19, 7, 29) }
         its("#{date_field}_presenter") { is_expected.to be_a Date }
         it 'is invalid' do
-          expect(subject.errors[date_field]).to include invalid_date_text
+          is_expected.to have_error_for(date_field).with_message(invalid_date_text)
         end
       end
     end

--- a/spec/support/shared/form_with_endpoint.rb
+++ b/spec/support/shared/form_with_endpoint.rb
@@ -1,10 +1,10 @@
-RSpec.shared_examples 'a form that belongs to an endpoint' do |form_name|
+RSpec.shared_examples 'a form that belongs to an endpoint' do |path|
   let(:escort) { create(:escort) }
   subject { described_class.new(escort) }
 
   describe '#url' do
     it 'returns the url where the form is submitted to' do
-      expect(subject.url).to eq "/escort/#{escort.id}/#{form_name}"
+      expect(subject.url).to eq "/escort/#{escort.id}/#{path}"
     end
   end
 end


### PR DESCRIPTION
- [x] create an audited move model
- [x] fix form instantiation in controller when name is multiple words
- [x] have hint label for the date generated dynamically(examples date in the hint is the current date)
- [x] create a move information form
- [x] make form accessible form the nav bar
- [x] provide a default origin of 'HMP Bedford'
- [x] date validation: dates cannot be in the past
- [x] add filling in the form to the completing escort feature spec
- [ ] tidy up duplicating attributes in the form spec(this applies to the other form specs too)
- [x] add captured move information to the summary page
- [x] allow linking back to the move information page from the summary by clicking the edit link
- [x] ~~validations when submitting a partially filled move information form? **HELP**~~
- [x] add summary page checks to spec
- [x] add the move information to the pdf
- [x] spec a pdf with move information present
- [x] Extract available form sections from helper
- [x] Extract forms - avoid listing them in the routes

![move_info_form](https://cloud.githubusercontent.com/assets/1006365/13472019/0444c40c-e0ab-11e5-8042-e9849b68a10e.png)

![move_info_pdf](https://cloud.githubusercontent.com/assets/1006365/13550733/211049c6-e31c-11e5-9ffe-fdd49d5b0ac6.png)
