### PR TITLE
Fix font kerning in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN rm -rf wkhtmltox
 
 RUN cp -r ./fonts/liberation_sans /usr/share/fonts/truetype/
 RUN fc-cache -f -v
+RUN cp ./fonts/10-wkhtmltopdf.conf /etc/fonts/conf.d/
 
 ENV UNICORN_PORT 3000
 EXPOSE $UNICORN_PORT

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ machine. You can find the relevant fonts in the `fonts/` directory. You should
 be able to add them to OS X by double clicking the font.
 
 The `Dockerfile` is responsible for setting up the fonts from the repo on the
-container.
+container. It also includes a font configuration file required to fix font
+hinting and anti-aliasing in the container when generating PDF's.
 
 ### `Environment Variables`
 

--- a/fonts/10-wkhtmltopdf.conf
+++ b/fonts/10-wkhtmltopdf.conf
@@ -1,0 +1,29 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+ <match target="font">
+  <edit mode="assign" name="rgba">
+   <const>rgb</const>
+  </edit>
+ </match>
+ <match target="font">
+  <edit mode="assign" name="hinting">
+   <bool>true</bool>
+  </edit>
+ </match>
+ <match target="font">
+  <edit mode="assign" name="hintstyle">
+   <const>hintslight</const>
+  </edit>
+ </match>
+ <match target="font">
+  <edit mode="assign" name="antialias">
+   <bool>true</bool>
+  </edit>
+ </match>
+  <match target="font">
+    <edit mode="assign" name="lcdfilter">
+      <const>lcddefault</const>
+    </edit>
+  </match>
+</fontconfig>


### PR DESCRIPTION
There is a known (1)issue in Debian distros around subpixel 
hinting & font smoothing. Link below provides a description
& an example font configuration for fixing it.

This was highlighted in (2)below the wkhtmltopdf issue.

The font configuration(according to the Readme found in
`fonts/config.d/`) relies on ordering hence the `10-` prefix.

1)  https://wiki.debian.org/Fonts#Subpixel-hinting_and_Font-smoothing

2) https://github.com/wkhtmltopdf/wkhtmltopdf/issues/45
##### before:

<img width="285" alt="screen shot 2016-03-03 at 18 23 35" src="https://cloud.githubusercontent.com/assets/1006365/13504632/34389e0a-e16d-11e5-8452-71cbcd3e60fd.png">
##### after:

<img width="260" alt="screen shot 2016-03-03 at 18 23 49" src="https://cloud.githubusercontent.com/assets/1006365/13504627/2ddd5f82-e16d-11e5-9c0f-f56950c0ff36.png">
