### PR TITLE
Assert particular order of form names

### DIFF
--- a/spec/forms/form/routing_spec.rb
+++ b/spec/forms/form/routing_spec.rb
@@ -4,19 +4,19 @@ RSpec.describe Form::Routing, type: :form do
   describe '.resource_list' do
     it 'returns a list of objects that respond to name' do
       expect(described_class.resource_list.map(&:name)).
-        to match_array %i[ identification risks move_information ]
+        to eq %i[ identification risks move_information ]
     end
 
     it 'returns a list of objects that respond to path' do
       expect(described_class.resource_list.map(&:path)).
-        to match_array %w[ identification risks move-information ]
+        to eq %w[ identification risks move-information ]
     end
   end
 
   describe '.form_names' do
     it 'returns an array of symbolized form names' do
       expect(described_class.form_names).
-        to match_array %i[ identification risks move_information ]
+        to eq %i[ identification risks move_information ]
     end
   end
 end


### PR DESCRIPTION
As the form names are ultimately used to present the
navigation sections the order matters & now the specs
assert the order.
