### PR TITLE
Risk population from back end

### DIFF
--- a/app/assets/stylesheets/pdf/_risk_summary.scss
+++ b/app/assets/stylesheets/pdf/_risk_summary.scss
@@ -6,6 +6,7 @@
 
 .risk {
   @extend .row;
+  @extend .no-break;
   > div {
     @extend .col;
   }
@@ -24,6 +25,7 @@
   }
   .content {
     @extend .dark-border;
+    padding: $padding-unit;
     min-height: 4.5em;
   }
 }

--- a/app/presenters/pdf/escort_presenter.rb
+++ b/app/presenters/pdf/escort_presenter.rb
@@ -11,5 +11,9 @@ module Pdf
     def move
       @move ||= Pdf::MovePresenter.new(@escort.move)
     end
+
+    def risks
+      @risks ||= Pdf::RisksPresenter.new(@escort.risk_information)
+    end
   end
 end

--- a/app/presenters/pdf/risks_presenter.rb
+++ b/app/presenters/pdf/risks_presenter.rb
@@ -1,0 +1,12 @@
+module Pdf
+  class RisksPresenter
+    def initialize(model)
+      @model = model
+    end
+
+    delegate :to_self_details, :violence_details, :from_others_details,
+      :escape_details, :intolerant_behaviour_details,
+      :prohibited_items_details, :non_association_details,
+      to: :@model
+  end
+end

--- a/app/views/pdfs/_risk_summary.html.erb
+++ b/app/views/pdfs/_risk_summary.html.erb
@@ -11,7 +11,7 @@
   <div class="risk">
     <div class="description">
       <div class="title"><strong><%= t('.risks_to_self') %></strong></div>
-      <div class="content"></div>
+      <div class="content"><%= risks.to_self_details %></div>
     </div>
     <div class="date">
       <div class="title"><%= t('.date_of_incident') %></div>
@@ -21,7 +21,7 @@
   <div class="risk">
     <div class="description">
       <div class="title"><strong><%= t('.violence') %></strong></div>
-      <div class="content"></div>
+      <div class="content"><%= risks.violence_details %></div>
     </div>
     <div class="date">
       <div class="title"><%= t('.date_of_incident') %></div>
@@ -31,7 +31,7 @@
   <div class="risk">
     <div class="description">
       <div class="title"><strong><%= t('.risk_from_others') %></strong></div>
-      <div class="content"></div>
+      <div class="content"><%= risks.from_others_details %></div>
     </div>
     <div class="date">
       <div class="title"><%= t('.date_of_incident') %></div>
@@ -41,7 +41,7 @@
   <div class="risk">
     <div class="description">
       <div class="title"><strong><%= t('.escort_escape_risk') %></strong></div>
-      <div class="content"></div>
+      <div class="content"><%= risks.escape_details %></div>
     </div>
     <div class="date">
       <div class="title"><%= t('.date_of_incident') %></div>
@@ -52,7 +52,7 @@
     <div class="description">
       <div class="title"><strong><%= t('.intolerant_behaviour') %></strong>
       </div>
-      <div class="content"></div>
+      <div class="content"><%= risks.intolerant_behaviour_details %></div>
     </div>
     <div class="date">
       <div class="title"><%= t('.date_of_incident') %></div>
@@ -62,7 +62,7 @@
   <div class="risk">
     <div class="description">
       <div class="title"><strong><%= t('.prohibited_items') %></strong></div>
-      <div class="content"></div>
+      <div class="content"><%= risks.prohibited_items_details %></div>
     </div>
     <div class="date">
       <div class="title"><%= t('.date_of_incident') %></div>
@@ -72,7 +72,7 @@
   <div class="risk">
     <div class="description">
       <div class="title"><strong><%= t('.non_association') %></strong></div>
-      <div class="content"></div>
+      <div class="content"><%= risks.non_association_details %></div>
     </div>
     <div class="date">
       <div class="title"><%= t('.date_of_incident') %></div>

--- a/app/views/pdfs/show.html.erb
+++ b/app/views/pdfs/show.html.erb
@@ -15,7 +15,7 @@
 <%= render('pdfs/prisoner', prisoner: escort.prisoner) %>
 <%= render('pdfs/front_page_markers') %>
 <%= render('pdfs/updates') %>
-<%= render('pdfs/risk_summary') %>
+<%= render('pdfs/risk_summary', risks: escort.risks) %>
 <%= render('pdfs/healthcare_needs') %>
 <%= render('pdfs/medication') %>
 <%= render('pdfs/healthcare_updates') %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -47,7 +47,20 @@ FactoryGirl.define do
   end
 
   factory :risk_information do
-    escort
+    to_self true
+    to_self_details 'Always ends up with scars'
+    violence true
+    violence_details 'Violent person'
+    from_others true
+    from_others_details 'Several risks from others'
+    escape true
+    escape_details 'Tried to escape several times'
+    intolerant_behaviour true
+    intolerant_behaviour_details 'Shouts often'
+    prohibited_items true
+    prohibited_items_details 'Carried knives several times'
+    non_association true
+    non_association_details 'Prisoner with Prison number Z6543XY'
   end
 
   factory :user do

--- a/spec/presenters/pdf/move_presenter_spec.rb
+++ b/spec/presenters/pdf/move_presenter_spec.rb
@@ -2,16 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Pdf::MovePresenter, type: :presenter do
   let(:escort) { create(:escort) }
-  let(:move) { escort.move }
+  let(:model) { escort.move }
 
-  subject { described_class.new(move) }
+  subject { described_class.new(model) }
 
-  %i[ origin destination reason ].each do |method|
-    it "delegates #{method} to the move model" do
-      expect(move).to receive(method)
-      subject.public_send(method)
-    end
-  end
+  it_behaves_like 'a presenter that delegates methods to the model',
+    %i[ origin destination reason ]
 
   %i[ day month year ].each do |method|
     it do

--- a/spec/presenters/pdf/prisoner_presenter_spec.rb
+++ b/spec/presenters/pdf/prisoner_presenter_spec.rb
@@ -2,15 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Pdf::PrisonerPresenter, type: :presenter do
   let(:escort) { create(:escort) }
-  subject { described_class.new(escort.prisoner) }
+  let(:model) { escort.prisoner }
 
-  %i[ family_name forenames prison_number nationality capitalized_sex
-      date_of_birth age cro_number pnc_number ].each do |method|
-    it "delegates #{method} to the prisoner model" do
-      expect(escort.prisoner).to receive(method)
-      subject.public_send(method)
-    end
-  end
+  subject { described_class.new(model) }
+
+  it_behaves_like 'a presenter that delegates methods to the model',
+    %i[ family_name forenames prison_number nationality capitalized_sex
+        date_of_birth age cro_number pnc_number ]
 
   %i[ day month year ].each do |method|
     it { is_expected.to delegate_method(method).to(:date_of_birth).with_prefix }

--- a/spec/presenters/pdf/risks_presenter_spec.rb
+++ b/spec/presenters/pdf/risks_presenter_spec.rb
@@ -2,16 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Pdf::RisksPresenter, type: :presenter do
   let(:escort) { create(:escort) }
-  let(:risks) { escort.risk_information }
+  let(:model) { escort.risk_information }
 
-  subject { described_class.new(risks) }
+  subject { described_class.new(model) }
 
-  %i[ to_self_details violence_details from_others_details escape_details
-      intolerant_behaviour_details prohibited_items_details
-      non_association_details ].each do |method|
-    it "delegates #{method} to the move model" do
-      expect(risks).to receive(method)
-      subject.public_send(method)
-    end
-  end
+  it_behaves_like 'a presenter that delegates methods to the model',
+    %i[ to_self_details violence_details from_others_details escape_details
+        intolerant_behaviour_details prohibited_items_details
+        non_association_details ]
 end

--- a/spec/presenters/pdf/risks_presenter_spec.rb
+++ b/spec/presenters/pdf/risks_presenter_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Pdf::RisksPresenter, type: :presenter do
+  let(:escort) { create(:escort) }
+  let(:risks) { escort.risk_information }
+
+  subject { described_class.new(risks) }
+
+  %i[ to_self_details violence_details from_others_details escape_details
+      intolerant_behaviour_details prohibited_items_details
+      non_association_details ].each do |method|
+    it "delegates #{method} to the move model" do
+      expect(risks).to receive(method)
+      subject.public_send(method)
+    end
+  end
+end

--- a/spec/presenters/summary/move_presenter_spec.rb
+++ b/spec/presenters/summary/move_presenter_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Summary::MovePresenter, type: :presenter do
   let(:escort) { create(:escort) }
-  let(:move) { escort.move }
+  let(:model) { escort.move }
 
-  subject { described_class.new(move) }
+  subject { described_class.new(model) }
 
   describe '#edit_section_link' do
     it 'returns a path to the move information form page' do
@@ -13,24 +13,20 @@ RSpec.describe Summary::MovePresenter, type: :presenter do
     end
   end
 
-  %i[ origin destination reason ].each do |method|
-    it "delegates #{method} to the move model" do
-      expect(move).to receive(method)
-      subject.public_send(method)
-    end
-  end
+  it_behaves_like 'a presenter that delegates methods to the model',
+    %i[ origin destination reason ]
 
   describe '#formatted_date_of_travel' do
     context 'when date_of_travel is present' do
       it 'returns a date in the format DD/MM/YYYY' do
-        move.date_of_travel = Date.civil(2016, 10, 23)
+        model.date_of_travel = Date.civil(2016, 10, 23)
         expect(subject.formatted_date_of_travel).to eq '23/10/2016'
       end
     end
 
     context 'when date_of_travel is not present' do
       it 'returns nil' do
-        move.date_of_travel = nil
+        model.date_of_travel = nil
         expect(subject.formatted_date_of_travel).to be_nil
       end
     end

--- a/spec/presenters/summary/prisoner_presenter_spec.rb
+++ b/spec/presenters/summary/prisoner_presenter_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Summary::PrisonerPresenter, type: :presenter do
   let(:escort) { create(:escort) }
-  subject { described_class.new(escort.prisoner) }
+  let(:model) { escort.prisoner }
+
+  subject { described_class.new(model) }
 
   describe '#edit_section_link' do
     it 'returns a path to the prisoner information form page' do
@@ -11,11 +13,7 @@ RSpec.describe Summary::PrisonerPresenter, type: :presenter do
     end
   end
 
-  %i[ family_name forenames prison_number nationality capitalized_sex
-      formatted_date_of_birth age cro_number pnc_number ].each do |method|
-    it "delegates #{method} to the prisoner model" do
-      expect(escort.prisoner).to receive(method)
-      subject.public_send(method)
-    end
-  end
+  it_behaves_like 'a presenter that delegates methods to the model',
+    %i[ family_name forenames prison_number nationality capitalized_sex
+        formatted_date_of_birth age cro_number pnc_number ]
 end

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe PdfGenerator, type: :service do
       travel_to(Date.new(2015, 2, 3)) do
         prisoner = build_stubbed(:prisoner)
         move = build_stubbed(:move)
-        escort = build_stubbed(:escort, prisoner: prisoner, move: move)
+        risks = build_stubbed(:risk_information)
+        escort = build_stubbed(:escort,
+          prisoner: prisoner, move: move, risk_information: risks)
         html = described_class.render(escort)
         @content = ActionController::Base.helpers.strip_tags(html)
       end
@@ -73,13 +75,13 @@ RSpec.describe PdfGenerator, type: :service do
     it 'generates the expected content for the risk summary section' do
       expect(content).to have_content('A2. Risk summary').
         and have_content('PNC / Prison number').
-        and have_content('Risks to self').
-        and have_content('Violence and risk to others').
-        and have_content('Risk from others').
-        and have_content('Escort escape risk').
-        and have_content('Intolerant behaviour towards others').
-        and have_content('Prohibited items').
-        and have_content('Non-association').
+        and have_content('Risks to self Always ends up with scars').
+        and have_content('Violence and risk to others Violent person').
+        and have_content('Risk from others Several risks from others').
+        and have_content('Escort escape risk Tried to escape several times').
+        and have_content('Intolerant behaviour towards others Shouts often').
+        and have_content('Prohibited items Carried knives several times').
+        and have_content('Non-association Prisoner with Prison number Z6543XY').
         and have_content('Date of incident').
         and have_content('Name of person filling in this section').
         and have_content('Signature')

--- a/spec/support/shared/presenter_with_delegation.rb
+++ b/spec/support/shared/presenter_with_delegation.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples 'a presenter that delegates methods to the model' do |methods|
+  methods.each do |method|
+    it "delegates #{method} to the model" do
+      expect(model).to receive(method)
+      subject.public_send(method)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Add CSS to prevent risks from being split over multiple lines where possible
- [x] Back-end integration to populate risks
