### PR TITLE
Introduce custom form helpers

### DIFF
--- a/app/assets/javascripts/descendent_elements.js
+++ b/app/assets/javascripts/descendent_elements.js
@@ -29,12 +29,13 @@
     };
 
     changeIgnoredIds = function (ids) {
-        var id, newId;
+        var id, newId, attrSelector;
         for (var i = 0; i < ids.length; i++) {
             id = ids[i];
             newId = id + '_no_events';
+            attrSelector = '[for=' + id + ']';
             $('#' + id).attr('id', newId);
-            $('[for=' + id).attr('for', newId);
+            $(attrSelector).attr('for', newId);
         }
     };
 

--- a/app/assets/stylesheets/_errors.scss
+++ b/app/assets/stylesheets/_errors.scss
@@ -7,20 +7,3 @@
   }
 }
 
-.field_with_errors {
-  @extend .error;
-  &:after {
-    visibility: hidden;
-    display: block;
-    content: "";
-    clear: both;
-    height: 0;
-  }
-  .inline & {
-    display: inline-block;
-    border-left: none;
-    padding-left: 0;
-    margin-right: 0;
-  }
-}
-

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -47,7 +47,7 @@
   }
 
   .js-enabled & {
-    .optional-section {
+    .optional-section:not(.error) {
       border-left: $grey-2 solid 4px;
       padding: 14px 0 14px 14px;
     }

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -46,10 +46,14 @@
     margin-top: 5px;
   }
 
-  .js-enabled & {
-    .optional-section:not(.error) {
-      border-left: $grey-2 solid 4px;
-      padding: 14px 0 14px 14px;
+  .optional-section {
+    border-left: $grey-2 solid 4px;
+    padding: 14px 0 14px 14px;
+    legend {
+      margin-bottom: 0.5em;
+    }
+    &.error {
+      border-left-color: $error-colour;
     }
   }
 }

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -1,15 +1,4 @@
 .search-wrapper {
-  .field_with_errors {
-    display: inline-block;
-    min-width: 50%;
-    border-left: none;
-    padding-left: 0;
-    margin-right: 0;
-    .form-control {
-      width: 100%;
-    }
-  }
-
   .button {
     padding: 0.4em 0.6em 0.25em 0.6em;
     .error & {

--- a/app/assets/stylesheets/ie7.scss
+++ b/app/assets/stylesheets/ie7.scss
@@ -12,13 +12,6 @@
   }
 }
 
-.new_search_prisoner {
-  .field_with_errors {
-    display: inline!important;
-  }
-}
-
-
 th, td {
   padding-right: 1em!important;
 }

--- a/app/assets/stylesheets/ie8.scss
+++ b/app/assets/stylesheets/ie8.scss
@@ -7,12 +7,3 @@
     width: 75%;
   }
 }
-
-.new_search_prisoner {
-  .field_with_errors {
-    input {
-      min-width: 95%;
-    }
-  }
-}
-

--- a/app/helpers/form_elements_helper.rb
+++ b/app/helpers/form_elements_helper.rb
@@ -1,28 +1,23 @@
 module FormElementsHelper
-  def date_fields(form, field)
-    error_container(form, field, 'form-date') do
-      yield
-    end
+  def date_fields(form, field, &_blk)
+    form_group_container(form, field, classes: 'form-date') { yield }
   end
 
   def single_field(form, field)
-    error_container(form, field) do
-      form.label(field, class: 'form-label-bold', for: field) +
+    form_group_container(form, field) do
+      join(
+        form.label(field, class: 'form-label-bold', for: field),
         form.text_field(field, class: 'string form-control', id: field)
+      )
     end
   end
 
-  def error_container(form, field, html_class = nil)
+  def form_group_container(form, field, classes: '', id: nil, &_blk)
     content_tag(
       :div,
-      class: html_classes(form, field, html_class),
-      id: "#{form.object.name}_#{field}"
+      class: html_classes(form, field, classes),
+      id: id || "#{form.object.name}_#{field}"
     ) { yield }
-  end
-
-  def form_group_container(classes:'', &_blk)
-    styles = ['form-group', classes].join(' ')
-    content_tag(:div, class: styles) { yield }
   end
 
   def hint_text(&_blk)

--- a/app/helpers/form_elements_helper.rb
+++ b/app/helpers/form_elements_helper.rb
@@ -1,21 +1,23 @@
 module FormElementsHelper
-  def date_fields(form, name, &blk)
-    error_container(form, name) {
-      capture(&blk)
-    }
+  def date_fields(form, field)
+    error_container(form, field, 'form-date') do
+      yield
+    end
   end
 
-  def error_container(form, name, options = { class: 'form-date group' }, &blk)
-    html_class = [options[:class]]
-    if form.object.errors.include?(name)
-      html_class << ' error'
+  def single_field(form, field)
+    error_container(form, field) do
+      form.label(field, class: 'form-label-bold', for: field) +
+        form.text_field(field, class: 'string form-control', id: field)
     end
+  end
+
+  def error_container(form, field, html_class = nil)
     content_tag(
       :div,
-      class: html_class,
-      id: "#{form.object.name}_#{name}",
-      &blk
-    )
+      class: html_classes(form, field, html_class),
+      id: "#{form.object.name}_#{field}"
+    ) { yield }
   end
 
   def form_group_container(classes:'', &_blk)
@@ -29,5 +31,11 @@ module FormElementsHelper
 
   def join(*strings)
     strings.flatten.inject(ActiveSupport::SafeBuffer.new, &:<<)
+  end
+
+  def html_classes(form, field, html_class)
+    html_classes = ['form-group', html_class]
+    html_classes << 'error' if form.object.errors.include?(field)
+    html_classes.join(' ')
   end
 end

--- a/app/helpers/form_elements_helper.rb
+++ b/app/helpers/form_elements_helper.rb
@@ -20,6 +20,21 @@ module FormElementsHelper
     ) { yield }
   end
 
+  def link_to_field_with_error(object, attribute)
+    # For "details" text areas we want the link to point to the
+    # container div so that the user can have some context regarding
+    # the error (the conatiner will contain the name heading) so we
+    # need to remove the "_details" part as the convention in the
+    # text toggle attributes(where this tends to be an issue) is to
+    # have an attribute and an accompanying attribute_details too.
+    field = attribute.to_s.gsub(/_details\Z/, '')
+
+    link_to(
+      object.errors.full_messages_for(attribute).first,
+      "##{object.class.name.underscore}_#{field}"
+    )
+  end
+
   def hint_text(&_blk)
     content_tag(:p, class: 'form-hint') { yield }
   end

--- a/app/helpers/text_toggle_form_elements_helper.rb
+++ b/app/helpers/text_toggle_form_elements_helper.rb
@@ -1,14 +1,19 @@
 module TextToggleFormElementsHelper
   # rubocop:disable MethodLength
   def text_toggle_container(form, name, i18n_scope, &_blk)
-    content_tag(:fieldset, class: 'js_has_optional_section') do
+    content_tag(
+      :fieldset,
+      class: 'js_has_optional_section',
+      id: "#{form.object.name}_#{name}"
+    ) do
       join(
         title_text(name, i18n_scope),
         hint_text { t("#{i18n_scope}.#{name}.help_text") },
-        form_group_container {
+        form_group_container(form, name, id: '') {
           join(
             clearable_radio_buttons(form, name, i18n_scope),
-            form_group_container(classes: 'optional-section') { yield }
+            form_group_container(
+              form, :"#{name}_details", classes: 'optional-section') { yield }
           )
         }
       )

--- a/app/views/escorts/_healthcare.html.erb
+++ b/app/views/escorts/_healthcare.html.erb
@@ -29,12 +29,6 @@
     )
 %>
 
-<%= form_group_container do %>
-  <%= f.label :medical_professional_name, class: 'form-label-bold' %>
-  <%= f.text_field :medical_professional_name, class: 'string form-control' %>
-<% end %>
+<%= single_field(f, :medical_professional_name) %>
 
-<%= form_group_container do %>
-  <%= f.label :contact_telephone, class: 'form-label-bold' %>
-  <%= f.text_field :contact_telephone, class: 'string form-control' %>
-<% end %>
+<%= single_field(f, :contact_telephone) %>

--- a/app/views/escorts/_healthcare.html.erb
+++ b/app/views/escorts/_healthcare.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <%= text_toggle_container(f, :disabilities, 'healthcare') do %>
-  <%= form_group_container do %>
+  <%= form_group_container(f, :disabilities) do %>
     <%= f.label :mpv_required, class: 'block-label inline' do %>
       <%= f.check_box :mpv_required %>
       <%= t('healthcare.mpv_required') %>

--- a/app/views/escorts/_move_information.html.erb
+++ b/app/views/escorts/_move_information.html.erb
@@ -1,24 +1,15 @@
-<div class="form-group">
-  <%= f.label :origin, class: 'form-label-bold' %>
-  <%= f.text_field :origin, class: 'string form-control' %>
-</div>
+<%= single_field(f, :origin) %>
 
-<div class="form-group">
-  <%= f.label :destination, class: 'form-label-bold' %>
-  <%= f.text_field :destination, class: 'string form-control' %>
-</div>
+<%= single_field(f, :destination) %>
 
 <div class="form-group">
   <%= date_fields(f, :date_of_travel) do %>
     <%= render 'shared/date_field_inputs',
-          f: f,
-          model: 'move_information',
-          date_field: 'date_of_travel',
-          hint: f.object.formatted_date_today %>
+      f: f,
+      model: 'move_information',
+      date_field: 'date_of_travel',
+      hint: f.object.formatted_date_today %>
   <% end %>
 </div>
 
-<div class="form-group">
-  <%= f.label :reason, class: 'form-label-bold' %>
-  <%= f.text_field :reason, class: 'string form-control' %>
-</div>
+<%= single_field(f, :reason) %>

--- a/app/views/escorts/_prisoner_information.html.erb
+++ b/app/views/escorts/_prisoner_information.html.erb
@@ -1,25 +1,19 @@
 <div class="form-group">
-  <%= f.label :prison_number, class: 'form-label-bold' %>
-  <%= f.object.prison_number %>
-</div>
-<div class="form-group">
-  <%= f.label :family_name, class: 'form-label-bold' %>
-  <%= f.text_field :family_name, class: 'string form-control' %>
-</div>
-<div class="form-group">
-  <%= f.label :forenames, class: 'form-label-bold' %>
-  <%= f.text_field :forenames, class: 'string form-control' %>
+  <span id="prison-number" class="form-label-bold" id="prison-number"><%= t('shared.prison_number') %></span>
+  <span aria-labelledby="prison-number"><%= f.object.prison_number %></span>
 </div>
 
-<div class="form-group">
-  <%= date_fields(f, :date_of_birth) do %>
-    <%= render 'shared/date_field_inputs',
-          f: f,
-          model: 'prisoner_information',
-          date_field: 'date_of_birth',
-          hint: nil %>
-  <% end %>
-</div>
+<%= single_field(f, :family_name) %>
+
+<%= single_field(f, :forenames) %>
+
+<%= date_fields(f, :date_of_birth) do %>
+  <%= render 'shared/date_field_inputs',
+    f: f,
+    model: 'prisoner_information',
+    date_field: 'date_of_birth',
+    hint: nil %>
+<% end %>
 
 <div class="form-group">
   <fieldset class="inline">
@@ -27,27 +21,18 @@
       <%= t('.sex.label') %>
     </legend>
     <%= f.label :sex, value: 'male', class: 'block-label' do %>
-        <%= t('.sex.male_label') %>
-        <%= f.radio_button :sex, 'male' %>
+      <%= t('.sex.male_label') %>
+      <%= f.radio_button :sex, 'male' %>
     <% end %>
     <%= f.label :sex, value: 'female', class: 'block-label' do %>
-        <%= t('.sex.female_label') %>
-        <%= f.radio_button :sex, 'female' %>
+      <%= t('.sex.female_label') %>
+      <%= f.radio_button :sex, 'female' %>
     <% end %>
   </fieldset>
 </div>
 
-<div class="form-group">
-  <%= f.label :nationality, class: 'form-label-bold' %>
-  <%= f.text_field :nationality, class: 'string form-control' %>
-</div>
+<%= single_field(f, :nationality) %>
 
-<div class="form-group">
-  <%= f.label :cro_number, class: 'form-label-bold' %>
-  <%= f.text_field :cro_number, class: 'string form-control' %>
-</div>
+<%= single_field(f, :cro_number) %>
 
-<div class="form-group">
-  <%= f.label :pnc_number, class: 'form-label-bold' %>
-  <%= f.text_field :pnc_number, class: 'string form-control' %>
-</div>
+<%= single_field(f, :pnc_number) %>

--- a/app/views/escorts/_risks.html.erb
+++ b/app/views/escorts/_risks.html.erb
@@ -1,5 +1,5 @@
 <%= text_toggle_container(f, :to_self, 'risk') do %>
-  <%= form_group_container do %>
+  <%= form_group_container(f, :open_acct) do %>
     <%= title_text(:open_acct, 'risk') %>
     <%= clearable_radio_buttons(f, :open_acct, 'risk') %>
   <% end %>

--- a/app/views/shared/flashes/_save_errors.erb
+++ b/app/views/shared/flashes/_save_errors.erb
@@ -6,11 +6,7 @@
       <ul class="error-summary-list">
         <% object.errors.each do |attribute| %>
             <li>
-              <%= link_to(
-                    object.errors.full_messages_for(attribute).first,
-                    "##{object.class.name.underscore}_#{attribute}"
-                  )
-              %>
+              <%= link_to_field_with_error(object, attribute) %>
             </li>
         <% end %>
       </ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,5 +10,8 @@ module MovingPeopleSafely
     config.phase = 'beta'
     config.product_type = 'service'
     config.feedback_url = ''
+    config.action_view.field_error_proc = proc do |html_tag, _instance|
+      html_tag
+    end
   end
 end


### PR DESCRIPTION
- [x] Introduce single_field and date_fields custom form helpers to manage the presentation of form fields and their associated inputs across the application.
- [x] Merge error_container and form_group_container into one method
- [x] Show red form field when an error message is present on text toggle input fields
- [x] Fix link to form field with error on text toggle input fields
- [x] Disable rails style error messages and remove style overrides
## Screenshots

The screenshots below show a range of states in Chrome and IE7/8 as at 1 April (3pm). This includes a 'faked' single field being required - not replicable in the application at the current time. 
<img width="1188" alt="ie7 vista" src="https://cloud.githubusercontent.com/assets/16000203/14209165/b8766f9e-f81a-11e5-9395-6cacc7d07d56.png">
<img width="1051" alt="ie8 win 7" src="https://cloud.githubusercontent.com/assets/16000203/14209169/b8791f82-f81a-11e5-876e-890e44c96fd6.png">
<img width="1133" alt="single and date field erors" src="https://cloud.githubusercontent.com/assets/16000203/14209166/b876cd22-f81a-11e5-8283-2c9163599552.png">
<img width="1188" alt="single and date field errors - ie7 on vista" src="https://cloud.githubusercontent.com/assets/16000203/14209168/b87875c8-f81a-11e5-9394-1807bf3f895e.png">
<img width="1102" alt="single and date field errors - ie8 on win 7" src="https://cloud.githubusercontent.com/assets/16000203/14209167/b8777a06-f81a-11e5-81a4-306a10404721.png">
