### PR TITLE
Update front page markers to reflect new designs

### DIFF
--- a/app/assets/stylesheets/pdf/_front_page_markers.scss
+++ b/app/assets/stylesheets/pdf/_front_page_markers.scss
@@ -6,12 +6,15 @@
   }
   .title {
     width: 23%;
+    padding-top: $padding-unit * 1.5;
   }
   .markers {
     width: 48%;
     margin-right: $margin-right;
-    border-right: 1px solid $light_grey;
     padding-right: $padding;
+    &.has-reference {
+      border-right: 1px solid $light_grey;
+    }
     .indicator {
       @extend .row;
       @extend .light-background;
@@ -36,7 +39,7 @@
     span {
       display: inline-block;
       &.health {
-        margin-top: 3.8em;
+        margin-top: 1.8em;
       }
       &.risk {
         margin-top: 4.1em;
@@ -47,4 +50,3 @@
     }
   }
 }
-

--- a/app/views/pdfs/_front_page_markers.html.erb
+++ b/app/views/pdfs/_front_page_markers.html.erb
@@ -1,122 +1,118 @@
-<div class="front-page-markers">
-  <div class="title">
-    <strong><%= t('.healthcare_information.title') %></strong>
-  </div>
-  <div class="markers">
-    <div class="indicator">
-      <div>
-        <div class="label-inline"><%= t('.healthcare_information.acct') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.yes_label') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.no_label') %></div>
-      </div>
+<div>
+  <div class="front-page-markers">
+    <div class="title">
+      &nbsp
     </div>
-    <div class="indicator">
-      <div>
-        <div class="label-inline"><%= t('.risks.allergies') %></div>
+    <div class="markers">
+      <div class="indicator">
+        <div>
+          <div class="label-inline"><%= t('.healthcare_information.acct') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline">Yes</div>
+          <div class="check-box"></div>
+          <div class="label-inline">No</div>
+        </div>
       </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.yes_label') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.no_label') %></div>
-      </div>
-    </div>
-    <div class="indicator">
-      <div>
-        <div class="label-inline"><%= t('.risks.disabilities') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.yes_label') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.no_label') %></div>
+      <div class="indicator">
+        <div>
+          <div class="label-inline"><%= t('.offence_information.cat_a') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline">Yes</div>
+          <div class="check-box"></div>
+          <div class="label-inline">No</div>
+        </div>
       </div>
     </div>
   </div>
-  <div class="notes">
-    <span class="health"><%= t('.healthcare_information.notes') %></span>
-  </div>
-</div>
-<div class="front-page-markers">
-  <div class="title">
-    <strong><%= t('.risks.title') %></strong>
-  </div>
-  <div class="markers">
-    <div class="indicator">
-      <div>
-        <div class="label-inline"><%= t('.risks.violence') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.yes_label') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.no_label') %></div>
-      </div>
-    </div>
-    <div class="indicator">
-      <div>
-        <div class="label-inline"><%= t('.risks.escape') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.yes_label') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.no_label') %></div>
-      </div>
-    </div>
-    <div class="indicator">
-      <div>
-        <div class="label-inline"><%= t('.risks.non_association') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.yes_label') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.no_label') %></div>
-      </div>
-    </div>
-  </div>
-  <div class="notes">
-    <span class="risk"><%= t('.risks.notes') %></span>
-  </div>
-</div>
-<div class="front-page-markers">
-  <div class="title">
-    <strong><%= t('.offence_information.title') %></strong>
-  </div>
-  <div class="markers">
-    <div class="indicator">
-      <div>
-        <div class="label-inline"><%= t('.offence_information.cat_a') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.yes_label') %></div>
-      </div>
-      <div>
-        <div class="check-box"></div>
-        <div class="label-inline"><%= t('.risks.no_label') %></div>
-      </div>
-    </div>
-  </div>
-  <div class="notes">
-    <span class="offence"><%= t('.offence_information.notes') %></span>
-  </div>
-</div>
 
+  <div class="front-page-markers">
+    <div class="title">
+      <strong><%= t('.healthcare_information.title') %></strong>
+    </div>
+    <div class="markers has-reference">
+      <div class="indicator">
+        <div>
+          <div class="label-inline"><%= t('.risks.allergies') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.yes_label') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.no_label') %></div>
+        </div>
+      </div>
+      <div class="indicator">
+        <div>
+          <div class="label-inline"><%= t('.risks.disabilities') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.yes_label') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.no_label') %></div>
+        </div>
+      </div>
+    </div>
+    <div class="notes">
+      <span class="health"><%= t('.healthcare_information.notes') %></span>
+    </div>
+  </div>
+
+  <div class="front-page-markers">
+    <div class="title">
+      <strong><%= t('.risks.title') %></strong>
+    </div>
+    <div class="markers has-reference">
+      <div class="indicator">
+        <div>
+          <div class="label-inline"><%= t('.risks.violence') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.yes_label') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.no_label') %></div>
+        </div>
+      </div>
+      <div class="indicator">
+        <div>
+          <div class="label-inline"><%= t('.risks.escape') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.yes_label') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.no_label') %></div>
+        </div>
+      </div>
+      <div class="indicator">
+        <div>
+          <div class="label-inline"><%= t('.risks.non_association') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.yes_label') %></div>
+        </div>
+        <div>
+          <div class="check-box"></div>
+          <div class="label-inline"><%= t('.risks.no_label') %></div>
+        </div>
+      </div>
+    </div>
+    <div class="notes">
+      <span class="risk"><%= t('.risks.notes') %></span>
+    </div>
+  </div>
+</div>

--- a/config/locales/pdf.en.yml
+++ b/config/locales/pdf.en.yml
@@ -21,7 +21,7 @@ en:
       risks:
         title: Risks overview
         notes: Section A2 Risk summary
-        violence: Violence and risk to others
+        violence: Violence
         escape: Escort escape risk
         allergies: Allergies
         disabilities: Disabilities


### PR DESCRIPTION
Placement and styling of this component changed to reflect new design.
# PDF with changes made

This screenshot shows the PDF with associated changes made. This does not include a separate change on the design (see 'Case number' addition to design provided in Ticket #108). I am checking whether that change is included separately or as part of this feature. 

<img width="820" alt="screen shot 2016-03-18 at 12 21 40" src="https://cloud.githubusercontent.com/assets/16000203/13877640/19f8ca36-ed04-11e5-81e9-3058ffde8941.png">
