### PR TITLE
Update copy to reflect latest version

### DIFF
--- a/app/views/escorts/_healthcare.html.erb
+++ b/app/views/escorts/_healthcare.html.erb
@@ -1,5 +1,5 @@
 <% %i[ physical_risk mental_risk
-       social_care_and_other allergies ].each do |attribute| %>
+       social_care_and_other ].each do |attribute| %>
   <%= render(
         'shared/toggle_with_details_field',
         f: f,
@@ -8,6 +8,41 @@
       )
   %>
 <% end %>
+
+<fieldset class="js_has_optional_section">
+  <div class="form-group">
+    <legend class="form-label-bold">
+      <span><%= t('healthcare.allergies.title') %></span>
+    </legend>
+    <p class="form-hint"><%= t('healthcare.allergies.help_text') %></p>
+    <div class="form-group">
+      <% { true => :yes, false => :no }.each do |value, translation_key| %>
+        <%= f.label :allergies, value: value, class: 'block-label inline' do %>
+          <%= f.radio_button :allergies, value %> <%= t(translation_key) %>
+        <% end %>
+      <% end %>
+
+      <%= f.radio_button :allergies, 'unknown', class: "visuallyhidden" %>
+      <%= f.label "allergies_unknown", t('healthcare.labels.clear'), class: 'unknown_value' %>
+
+      <div class="form-group optional-section">
+        <div class="form-group">
+        <%= f.label :mpv_required, class: 'block-label inline' do %>
+          <%= f.check_box :mpv_required %>
+          <%= t('healthcare.mpv_required') %>
+        <% end %>
+        </div>
+        <%= f.label "allergies_details", t('healthcare.labels.details_help_text') %>
+        <p class="form-hint"><%= t('healthcare.allergies.details_guidance_text') %></p>
+        <%= f.text_area "allergies_details",
+            autocomplete: 'off',
+            class: 'form-control',
+            id: "#{f.object.name}_allergies_details"
+        %>
+      </div>
+    </div>
+  </div>
+</fieldset>
 
 <fieldset class="js_has_optional_section">
   <div class="form-group">
@@ -33,6 +68,7 @@
         <% end %>
         </div>
         <%= f.label "disabilities_details", t('healthcare.disabilities.details_help_text') %>
+        <p class="form-hint"><%= t('healthcare.disabilities.details_guidance_text') %></p>
         <%= f.text_area "disabilities_details",
             autocomplete: 'off',
             class: 'form-control',

--- a/config/locales/healthcare.en.yml
+++ b/config/locales/healthcare.en.yml
@@ -10,29 +10,32 @@ en:
   healthcare:
     labels:
       clear: Clear selection
+      details_help_text: Give details and how the issues might be a risk during the move
     physical_risk:
-      title: Physical health risks
-      help_text: Does the prisoner have any physical health issues?
-      details_help_text: Enter details of the prisoner's physical health issues
+      title: Physical health
+      help_text: Does the prisoner have any physical health needs?
+      details_help_text: :'healthcare.labels.details_help_text'
     mental_risk:
-      title: Mental health risks
-      help_text: Does the prisoner have any mental health issues?
-      details_help_text: Enter details of the prisoner's mental health issues
+      title: Mental health
+      help_text: Does the prisoner have any mental health needs?
+      details_help_text: :'healthcare.labels.details_help_text'
     social_care_and_other:
-      title: Social care needs and other healthcare needs
-      help_text: Does the prisoner have any social care or other healthcare needs?
-      details_help_text: Enter details of the prisoner's social care and other healthcare needs
+      title: Social care
+      help_text: Does the prisoner have social care or any other medical needs?
+      details_help_text: :'healthcare.labels.details_help_text'
     allergies:
       title: Allergies
       help_text: Does the prisoner have any allergies?
-      details_help_text: Enter details of the prisoner's allergies
+      details_help_text: :'healthcare.labels.details_help_text'
+      details_guidance_text: Give details of food allergies, eg nuts or medical allergies, eg ibuprofen or any other allergies. Also give details of food intolerances, eg wheat, gluten dairy. Include whether the allergy is severe or mild and list any particular triggers.
     disabilities:
       title: Disabilities
       help_text: Does the prisoner have any disabilities?
-      details_help_text: Enter details of the prisoner's disabilities
-    mpv_required: Does the prisoner require an MPV?
+      details_help_text: Give details of their disabilities, their disability needs, as well as potential risks during the move
+      details_guidance_text: Give details of any equipment necessary for moving, eg special vehicles, walking frames. Also any communication support that might be needed.
+    mpv_required: Do they need an MPV?
     medication:
       title: Medication
-      help_text: Does the prisoner require any medication?
-      details_help_text: Enter details of the medication and administration information
+      help_text: Does the prisoner need medication?
+      details_help_text: Give details of the medication needed and how it is administered
 


### PR DESCRIPTION
I've just updated the copy and used the existing approach: i.e. where it's a simple block, pass some values to a partial, but include it as a HTML block where there are variations

The problem is that the latest copy changes mean that most of the blocks are now in the template, rather than coming from the partial because there are 3 separate variations of the snippet now. 

@dan-palmer @cesidio I'm wondering whether all this code should be in a helper to clean up the view. What do you think? 
