### PR TITLE
Copy Updates & Optional Text Area Refactor

### DIFF
--- a/app/helpers/form_elements_helper.rb
+++ b/app/helpers/form_elements_helper.rb
@@ -17,4 +17,17 @@ module FormElementsHelper
       &blk
     )
   end
+
+  def form_group_container(classes:'', &_blk)
+    styles = ['form-group', classes].join(' ')
+    content_tag(:div, class: styles) { yield }
+  end
+
+  def hint_text(&_blk)
+    content_tag(:p, class: 'form-hint') { yield }
+  end
+
+  def join(*strings)
+    strings.flatten.inject(ActiveSupport::SafeBuffer.new, &:<<)
+  end
 end

--- a/app/helpers/text_toggle_form_elements_helper.rb
+++ b/app/helpers/text_toggle_form_elements_helper.rb
@@ -14,29 +14,10 @@ module TextToggleFormElementsHelper
     end
   end # rubocop:enable MethodLength
 
-  def details_text_area(form, name)
-    form.text_area(
-      "#{name}_details",
-      autocomplete: 'off',
-      class: 'form-control',
-      id: "#{form.object.name}_#{name}_details"
-    )
-  end
-
-  def details_help_text(form, name, i18n_scope)
-    form.label(
-      "#{name}_details",
-      t("#{i18n_scope}.#{name}.details_help_text")
-    )
-  end
-
-  def details_guidance_text(name, i18n_scope)
-    hint_text { t("#{i18n_scope}.#{name}.details_guidance_text") }
-  end
-
   def details_text_area_with_help_text(form, name, i18n_scope)
     join(
       details_help_text(form, name, i18n_scope),
+      details_guidance_text(name, i18n_scope),
       details_text_area(form, name)
     )
   end
@@ -77,5 +58,28 @@ module TextToggleFormElementsHelper
         class: 'unknown_value'
       )
     )
+  end
+
+  def details_text_area(form, name)
+    form.text_area(
+      "#{name}_details",
+      autocomplete: 'off',
+      class: 'form-control',
+      id: "#{form.object.name}_#{name}_details"
+    )
+  end
+
+  def details_help_text(form, name, i18n_scope)
+    form.label(
+      "#{name}_details",
+      t("#{i18n_scope}.#{name}.details_help_text")
+    )
+  end
+
+  def details_guidance_text(name, i18n_scope)
+    # Guidance text does not necessarily apply to every textarea &
+    # can be blank theefore we check its existence
+    i18n_path = "#{i18n_scope}.#{name}.details_guidance_text"
+    hint_text { t(i18n_path) } if I18n.exists?(i18n_path, I18n.locale)
   end
 end

--- a/app/helpers/text_toggle_form_elements_helper.rb
+++ b/app/helpers/text_toggle_form_elements_helper.rb
@@ -1,0 +1,81 @@
+module TextToggleFormElementsHelper
+  # rubocop:disable MethodLength
+  def text_toggle_container(form, name, i18n_scope, &_blk)
+    content_tag(:fieldset, class: 'js_has_optional_section') do
+      join(
+        title_with_hint(name, i18n_scope),
+        form_group_container {
+          join(
+            clearable_radio_buttons(form, name, i18n_scope),
+            form_group_container(classes: 'optional-section') { yield }
+          )
+        }
+      )
+    end
+  end # rubocop:enable MethodLength
+
+  def details_text_area(form, name)
+    form.text_area(
+      "#{name}_details",
+      autocomplete: 'off',
+      class: 'form-control',
+      id: "#{form.object.name}_#{name}_details"
+    )
+  end
+
+  def details_help_text(form, name, i18n_scope)
+    form.label(
+      "#{name}_details",
+      t("#{i18n_scope}.#{name}.details_help_text")
+    )
+  end
+
+  def details_guidance_text(name, i18n_scope)
+    hint_text { t("#{i18n_scope}.#{name}.details_guidance_text") }
+  end
+
+  def details_text_area_with_help_text(form, name, i18n_scope)
+    join(
+      details_help_text(form, name, i18n_scope),
+      details_text_area(form, name)
+    )
+  end
+
+  def title_with_hint(name, i18n_scope)
+    join(
+      content_tag(:legend, class: 'form-label-bold') {
+        content_tag(:span) { t("#{i18n_scope}.#{name}.title") }
+      },
+      hint_text { t("#{i18n_scope}.#{name}.help_text") }
+    )
+  end
+
+  def clearable_radio_buttons(form, name, i18n_scope)
+    join(
+      yes_no_radio_buttons(form, name),
+      clear_selection_radio_button(form, name, i18n_scope)
+    )
+  end
+
+  def yes_no_radio_buttons(form, name)
+    { true => :yes, false => :no }.map do |(value, translation_key)|
+      form.label(name, value: value, class: 'block-label inline') do
+        join(
+          form.radio_button(name, value),
+          t(translation_key)
+        )
+      end
+    end
+  end
+
+  def clear_selection_radio_button(form, name, i18n_scope)
+    join(
+      form.radio_button(name, 'unknown', class: 'visuallyhidden'),
+      form.label(
+        "#{name}_unknown",
+        t("#{i18n_scope}.labels.clear"),
+        class: 'unknown_value'
+      )
+    )
+  end
+end

--- a/app/views/escorts/_healthcare.html.erb
+++ b/app/views/escorts/_healthcare.html.erb
@@ -1,5 +1,5 @@
 <% %i[ physical_risk mental_risk
-       social_care_and_other allergies ].each do |attribute| %>
+       social_care_and_other ].each do |attribute| %>
   <%= render(
         'shared/toggle_with_details_field',
         f: f,
@@ -8,6 +8,35 @@
       )
   %>
 <% end %>
+
+<fieldset class="js_has_optional_section">
+  <div class="form-group">
+    <legend class="form-label-bold">
+      <span><%= t('healthcare.allergies.title') %></span>
+    </legend>
+    <p class="form-hint"><%= t('healthcare.allergies.help_text') %></p>
+    <div class="form-group">
+      <% { true => :yes, false => :no }.each do |value, translation_key| %>
+        <%= f.label :allergies, value: value, class: 'block-label inline' do %>
+          <%= f.radio_button :allergies, value %> <%= t(translation_key) %>
+        <% end %>
+      <% end %>
+
+      <%= f.radio_button :allergies, 'unknown', class: "visuallyhidden" %>
+      <%= f.label "allergies_unknown", t('healthcare.labels.clear'), class: 'unknown_value' %>
+
+      <div class="form-group optional-section">
+        <%= f.label "allergies_details", t('healthcare.labels.details_help_text') %>
+        <p class="form-hint"><%= t('healthcare.allergies.details_guidance_text') %></p>
+        <%= f.text_area "allergies_details",
+            autocomplete: 'off',
+            class: 'form-control',
+            id: "#{f.object.name}_allergies_details"
+        %>
+      </div>
+    </div>
+  </div>
+</fieldset>
 
 <fieldset class="js_has_optional_section">
   <div class="form-group">
@@ -33,6 +62,7 @@
         <% end %>
         </div>
         <%= f.label "disabilities_details", t('healthcare.disabilities.details_help_text') %>
+        <p class="form-hint"><%= t('healthcare.disabilities.details_guidance_text') %></p>
         <%= f.text_area "disabilities_details",
             autocomplete: 'off',
             class: 'form-control',

--- a/app/views/escorts/_healthcare.html.erb
+++ b/app/views/escorts/_healthcare.html.erb
@@ -9,69 +9,23 @@
   %>
 <% end %>
 
-<fieldset class="js_has_optional_section">
-  <div class="form-group">
-    <legend class="form-label-bold">
-      <span><%= t('healthcare.allergies.title') %></span>
-    </legend>
-    <p class="form-hint"><%= t('healthcare.allergies.help_text') %></p>
-    <div class="form-group">
-      <% { true => :yes, false => :no }.each do |value, translation_key| %>
-        <%= f.label :allergies, value: value, class: 'block-label inline' do %>
-          <%= f.radio_button :allergies, value %> <%= t(translation_key) %>
-        <% end %>
-      <% end %>
+<%= text_toggle_container(f, :allergies, 'healthcare') do %>
+  <%= details_help_text(f, :allergies, 'healthcare') %>
+  <%= details_guidance_text(:allergies, 'healthcare') %>
+  <%= details_text_area(f, :allergies) %>
+<% end %>
 
-      <%= f.radio_button :allergies, 'unknown', class: "visuallyhidden" %>
-      <%= f.label "allergies_unknown", t('healthcare.labels.clear'), class: 'unknown_value' %>
-
-      <div class="form-group optional-section">
-        <%= f.label "allergies_details", t('healthcare.labels.details_help_text') %>
-        <p class="form-hint"><%= t('healthcare.allergies.details_guidance_text') %></p>
-        <%= f.text_area "allergies_details",
-            autocomplete: 'off',
-            class: 'form-control',
-            id: "#{f.object.name}_allergies_details"
-        %>
-      </div>
-    </div>
-  </div>
-</fieldset>
-
-<fieldset class="js_has_optional_section">
-  <div class="form-group">
-    <legend class="form-label-bold">
-      <span><%= t('healthcare.disabilities.title') %></span>
-    </legend>
-    <p class="form-hint"><%= t('healthcare.disabilities.help_text') %></p>
-    <div class="form-group">
-      <% { true => :yes, false => :no }.each do |value, translation_key| %>
-        <%= f.label :disabilities, value: value, class: 'block-label inline' do %>
-          <%= f.radio_button :disabilities, value %> <%= t(translation_key) %>
-        <% end %>
-      <% end %>
-
-      <%= f.radio_button :disabilities, 'unknown', class: "visuallyhidden" %>
-      <%= f.label "disabilities_unknown", t('healthcare.labels.clear'), class: 'unknown_value' %>
-
-      <div class="form-group optional-section">
-        <div class="form-group">
-        <%= f.label :mpv_required, class: 'block-label inline' do %>
-          <%= f.check_box :mpv_required %>
-          <%= t('healthcare.mpv_required') %>
-        <% end %>
-        </div>
-        <%= f.label "disabilities_details", t('healthcare.disabilities.details_help_text') %>
-        <p class="form-hint"><%= t('healthcare.disabilities.details_guidance_text') %></p>
-        <%= f.text_area "disabilities_details",
-            autocomplete: 'off',
-            class: 'form-control',
-            id: "#{f.object.name}_disabilities_details"
-        %>
-      </div>
-    </div>
-  </div>
-</fieldset>
+<%= text_toggle_container(f, :disabilities, 'healthcare') do %>
+  <%= form_group_container do %>
+    <%= f.label :mpv_required, class: 'block-label inline' do %>
+      <%= f.check_box :mpv_required %>
+      <%= t('healthcare.mpv_required') %>
+    <% end %>
+  <% end %>
+  <%= details_help_text(f, :disabilities, 'healthcare') %>
+  <%= details_guidance_text(:disabilities, 'healthcare') %>
+  <%= details_text_area(f, :disabilities) %>
+<% end %>
 
 <%= render(
       'shared/toggle_with_details_field',
@@ -81,13 +35,13 @@
     )
 %>
 
-<div class="form-group">
+<%= form_group_container do %>
   <%= f.label :medical_professional_name, class: 'form-label-bold' %>
   <%= f.text_field :medical_professional_name, class: 'string form-control' %>
-</div>
+<% end %>
 
-<div class="form-group">
+<%= form_group_container do %>
   <%= f.label :contact_telephone, class: 'form-label-bold' %>
   <%= f.text_field :contact_telephone, class: 'string form-control' %>
-</div>
+<% end %>
 

--- a/app/views/escorts/_healthcare.html.erb
+++ b/app/views/escorts/_healthcare.html.erb
@@ -1,5 +1,7 @@
-<% %i[ physical_risk mental_risk
-       social_care_and_other ].each do |attribute| %>
+<% %i[ physical_risk
+       mental_risk
+       social_care_and_other
+       allergies ].each do |attribute| %>
   <%= render(
         'shared/toggle_with_details_field',
         f: f,
@@ -9,12 +11,6 @@
   %>
 <% end %>
 
-<%= text_toggle_container(f, :allergies, 'healthcare') do %>
-  <%= details_help_text(f, :allergies, 'healthcare') %>
-  <%= details_guidance_text(:allergies, 'healthcare') %>
-  <%= details_text_area(f, :allergies) %>
-<% end %>
-
 <%= text_toggle_container(f, :disabilities, 'healthcare') do %>
   <%= form_group_container do %>
     <%= f.label :mpv_required, class: 'block-label inline' do %>
@@ -22,9 +18,7 @@
       <%= t('healthcare.mpv_required') %>
     <% end %>
   <% end %>
-  <%= details_help_text(f, :disabilities, 'healthcare') %>
-  <%= details_guidance_text(:disabilities, 'healthcare') %>
-  <%= details_text_area(f, :disabilities) %>
+  <%= details_text_area_with_help_text(f, :disabilities, 'healthcare') %>
 <% end %>
 
 <%= render(
@@ -44,4 +38,3 @@
   <%= f.label :contact_telephone, class: 'form-label-bold' %>
   <%= f.text_field :contact_telephone, class: 'string form-control' %>
 <% end %>
-

--- a/app/views/shared/_toggle_with_details_field.html.erb
+++ b/app/views/shared/_toggle_with_details_field.html.erb
@@ -1,27 +1,3 @@
-<fieldset class="js_has_optional_section">
-  <div class="form-group">
-    <legend class="form-label-bold">
-      <span><%= t("#{i18n_scope}.#{attribute}.title") %></span>
-    </legend>
-    <p class="form-hint"><%= t("#{i18n_scope}.#{attribute}.help_text") %></p>
-    <div class="form-group">
-      <% { true => :yes, false => :no }.each do |value, translation_key| %>
-        <%= f.label attribute, value: value, class: 'block-label inline' do %>
-          <%= f.radio_button attribute, value %> <%= t(translation_key) %>
-        <% end %>
-      <% end %>
-
-      <%= f.radio_button attribute, 'unknown', class: "visuallyhidden" %>
-      <%= f.label "#{attribute}_unknown", t("#{i18n_scope}.labels.clear"), class: 'unknown_value' %>
-
-      <div class="form-group optional-section">
-        <%= f.label "#{attribute}_details", t("#{i18n_scope}.#{attribute}.details_help_text") %>
-        <%= f.text_area "#{attribute}_details",
-            autocomplete: 'off',
-            class: 'form-control',
-            id: "#{f.object.name}_#{attribute}_details"
-        %>
-      </div>
-    </div>
-  </div>
-</fieldset>
+<%= text_toggle_container(f, attribute, i18n_scope) do %>
+  <%= details_text_area_with_help_text(f, attribute, i18n_scope) %>
+<% end %>

--- a/config/locales/healthcare.en.yml
+++ b/config/locales/healthcare.en.yml
@@ -10,29 +10,32 @@ en:
   healthcare:
     labels:
       clear: Clear selection
+      details_help_text: Give details and how the issues might be a risk during the move
     physical_risk:
-      title: Physical health risks
-      help_text: Does the prisoner have any physical health issues?
-      details_help_text: Enter details of the prisoner's physical health issues
+      title: Physical health
+      help_text: Does the prisoner have any physical health needs?
+      details_help_text: :'healthcare.labels.details_help_text'
     mental_risk:
-      title: Mental health risks
-      help_text: Does the prisoner have any mental health issues?
-      details_help_text: Enter details of the prisoner's mental health issues
+      title: Mental health
+      help_text: Does the prisoner have any mental health needs?
+      details_help_text: :'healthcare.labels.details_help_text'
     social_care_and_other:
-      title: Social care needs and other healthcare needs
-      help_text: Does the prisoner have any social care or other healthcare needs?
-      details_help_text: Enter details of the prisoner's social care and other healthcare needs
+      title: Social care
+      help_text: Does the prisoner have social care or any other medical needs?
+      details_help_text: :'healthcare.labels.details_help_text'
     allergies:
       title: Allergies
       help_text: Does the prisoner have any allergies?
-      details_help_text: Enter details of the prisoner's allergies
+      details_help_text: :'healthcare.labels.details_help_text'
+      details_guidance_text: Give details of food allergies, eg nuts or medical allergies, eg ibuprofen or any other allergies. Also give details of food intolerances, eg wheat, gluten dairy. Include whether the allergy is severe or mild and list any particular triggers.
     disabilities:
       title: Disabilities
       help_text: Does the prisoner have any disabilities?
-      details_help_text: Enter details of the prisoner's disabilities
-    mpv_required: Does the prisoner require an MPV?
+      details_help_text: Give details of their disabilities, their disability needs, as well as potential risks during the move
+      details_guidance_text: Give details of any equipment necessary for moving, eg special vehicles, walking frames. Also any communication support that might be needed.
+    mpv_required: Do they need an MPV?
     medication:
       title: Medication
-      help_text: Does the prisoner require any medication?
-      details_help_text: Enter details of the medication and administration information
+      help_text: Does the prisoner need medication?
+      details_help_text: Give details of the medication needed and how it is administered
 

--- a/spec/features/managing_an_escorts_healthcare_spec.rb
+++ b/spec/features/managing_an_escorts_healthcare_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'managing an escorts healthcare', type: :feature do
   let(:link_name)                 { 'Healthcare' }
-  let(:healthcare_field_category) { 'Physical health risks' }
+  let(:healthcare_field_category) { 'Physical health' }
   let(:healthcare_field_text)     { 'Broken leg' }
 
   scenario 'adding a healthcare field without details' do

--- a/spec/support/feature_helpers/healthcare_form.rb
+++ b/spec/support/feature_helpers/healthcare_form.rb
@@ -5,7 +5,7 @@ module FeatureHelpers
       options.each do |key, (radio_value, textarea_value)|
         fill_in_healthcare_field(key, radio_value, textarea_value)
       end
-      check 'Does the prisoner require an MPV?'
+      check 'Do they need an MPV?'
       click_save
     end
 
@@ -21,8 +21,8 @@ module FeatureHelpers
     end
 
     def build_healthcare_properties
-      ['Physical health risks', 'Mental health risks',
-       'Social care needs and other healthcare needs', 'Allergies',
+      ['Physical health', 'Mental health',
+       'Social care', 'Allergies',
        'Disabilities', 'Medication'].each_with_index.
         each_with_object({}) do |(r, i), o|
         o[r] = (i.odd? ? ['Yes', 'Some user input'] : ['No', nil])


### PR DESCRIPTION
- [x] Copy amendments to healthcare section
- [x] Refactor optional text areas to DRY up and also improve readability

~~\- [ ] Use new helpers across partials~~

> I've updated the copy and related tests. This continues to use the pattern implemented previously, i.e. iterate over a list and render a partial unless the snippet varies slightly (in which case you render the HTML inline). I'm wondering if this is still the right approach since we've got three variants of the snippet now. 
> 
> I'm wondering whether we should move the HTML generation into a helper which renders the variations (or not) depending on what arguments it is passed. 
> 
> @dan-palmer @cesidio What's your view on this? 
