### PR TITLE
Use named date formats when converting to strings

### DIFF
--- a/app/forms/move_information.rb
+++ b/app/forms/move_information.rb
@@ -9,7 +9,7 @@ class MoveInformation < Form
   validates :date_of_travel, present_or_future_date: true
 
   def formatted_date_today
-    Date.today.strftime('%d %m %Y')
+    Date.today.to_s(:day_month_year)
   end
 
   def target

--- a/app/models/escort.rb
+++ b/app/models/escort.rb
@@ -16,7 +16,7 @@ class Escort < ActiveRecord::Base
     prefix: true, to: :prisoner
 
   def formatted_updated_at
-    updated_at.strftime('%H:%M %d/%m/%Y')
+    updated_at.to_s(:time_with_slashed_day_month_year)
   end
 
   def prisoner

--- a/app/models/prisoner.rb
+++ b/app/models/prisoner.rb
@@ -8,7 +8,7 @@ class Prisoner < ActiveRecord::Base
 
   def formatted_date_of_birth
     if date_of_birth.present?
-      date_of_birth.strftime('%d/%m/%Y')
+      date_of_birth.to_s(:slashed_day_month_year)
     end
   end
 

--- a/app/presenters/summary/move_presenter.rb
+++ b/app/presenters/summary/move_presenter.rb
@@ -13,7 +13,7 @@ module Summary
 
     def formatted_date_of_travel
       if date_of_travel.present?
-        date_of_travel.strftime('%d/%m/%Y')
+        date_of_travel.to_s(:slashed_day_month_year)
       end
     end
   end

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,5 @@
+# Provide named date formats that hook into Rails DATE_FORMATS hash
+
+Date::DATE_FORMATS[:day_month_year] = '%d %m %Y'
+Date::DATE_FORMATS[:slashed_day_month_year] = '%d/%m/%Y'
+Time::DATE_FORMATS[:time_with_slashed_day_month_year] = '%H:%M %d/%m/%Y'

--- a/spec/config/date_format_spec.rb
+++ b/spec/config/date_format_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'custom date formats', type: :config do
+  around(:each) do |example|
+    travel_to(Time.new(2016, 2, 3, 9, 30, 0)) { example.run }
+  end
+
+  describe 'Date formats' do
+    subject { Date.today }
+
+    describe 'day_month_year' do
+      it 'returns a string in the format DD MM YYYY' do
+        expect(subject.to_s(:day_month_year)).to eq '03 02 2016'
+      end
+    end
+
+    describe 'slashed_day_month_year' do
+      it 'returns a string in the format DD/MM/YYYY' do
+        expect(subject.to_s(:slashed_day_month_year)).to eq '03/02/2016'
+      end
+    end
+  end
+
+  describe 'Time formats' do
+    subject { Time.now }
+
+    describe 'time_with_slashed_day_month_year' do
+      it 'returns a string in the format HH:MM DD/MM/YYYY' do
+        output =  subject.to_s(:time_with_slashed_day_month_year)
+        expect(output).to eq '09:30 03/02/2016'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides a number of named date formats that hook
into Rails DATE_FORMATS hash for consistent use in
the application.
