### PR TITLE
Add ability to set whether an ACCT is open or not

### DIFF
--- a/app/assets/javascripts/descendent_elements.js
+++ b/app/assets/javascripts/descendent_elements.js
@@ -2,7 +2,7 @@
 
 (function ($) {
 
-    var trueChecked, falseChecked, manageState, setVisibility;
+    var trueChecked, falseChecked, manageState, setVisibility, changeIgnoredIds;
 
     trueChecked = function ($block) {
         return $block.find('[id$=_true]:checked').length == 1;
@@ -28,16 +28,37 @@
         setVisibility(showUnknownLabel, $unknownLabel);
     };
 
-    $.fn.descendentElements = function () {
+    changeIgnoredIds = function (ids) {
+        var id, newId;
+        for (var i = 0; i < ids.length; i++) {
+            id = ids[i];
+            newId = id + '_no_events';
+            $('#' + id).attr('id', newId);
+            $('[for=' + id).attr('for', newId);
+        }
+    };
+
+    $.fn.descendentElements = function (options) {
+
+        var settings = $.extend({}, $.fn.descendentElements.defaults, options);
+
+        changeIgnoredIds(settings.ignored_checkboxes);
+
         return this.each(function () {
             var $this = $(this);
+
             manageState($this);
+
             $this.on('change', function (e) {
                 manageState($this);
             })
         })
     };
 
+    $.fn.descendentElements.defaults = {
+        ignored_checkboxes: ''
+    }
+
 }(jQuery));
 
-$('.js_has_optional_section').descendentElements();
+$('.js_has_optional_section').descendentElements({ignored_checkboxes: ['risks_open_acct_true', 'risks_open_acct_false', 'risks_open_acct_unknown']});

--- a/app/forms/risks.rb
+++ b/app/forms/risks.rb
@@ -9,6 +9,8 @@ class Risks < Form
   text_toggle_attribute :prohibited_items
   text_toggle_attribute :non_association
 
+  attribute :open_acct, MaybeBoolean
+
   def target
     super.risk_information
   end

--- a/app/forms/risks.rb
+++ b/app/forms/risks.rb
@@ -11,6 +11,10 @@ class Risks < Form
 
   attribute :open_acct, MaybeBoolean
 
+  def open_acct
+    super if to_self
+  end
+
   def target
     super.risk_information
   end

--- a/app/forms/risks.rb
+++ b/app/forms/risks.rb
@@ -1,10 +1,13 @@
 class Risks < Form
   include Form::TextToggleAttribute
 
-  GENERAL = %i[ to_self violence from_others escape intolerant_behaviour
-                prohibited_items non_association ].freeze
-
-  GENERAL.each(&method(:text_toggle_attribute))
+  text_toggle_attribute :to_self
+  text_toggle_attribute :violence
+  text_toggle_attribute :from_others
+  text_toggle_attribute :escape
+  text_toggle_attribute :intolerant_behaviour
+  text_toggle_attribute :prohibited_items
+  text_toggle_attribute :non_association
 
   def target
     super.risk_information

--- a/app/helpers/text_toggle_form_elements_helper.rb
+++ b/app/helpers/text_toggle_form_elements_helper.rb
@@ -3,7 +3,8 @@ module TextToggleFormElementsHelper
   def text_toggle_container(form, name, i18n_scope, &_blk)
     content_tag(:fieldset, class: 'js_has_optional_section') do
       join(
-        title_with_hint(name, i18n_scope),
+        title_text(name, i18n_scope),
+        hint_text { t("#{i18n_scope}.#{name}.help_text") },
         form_group_container {
           join(
             clearable_radio_buttons(form, name, i18n_scope),
@@ -22,13 +23,10 @@ module TextToggleFormElementsHelper
     )
   end
 
-  def title_with_hint(name, i18n_scope)
-    join(
-      content_tag(:legend, class: 'form-label-bold') {
-        content_tag(:span) { t("#{i18n_scope}.#{name}.title") }
-      },
-      hint_text { t("#{i18n_scope}.#{name}.help_text") }
-    )
+  def title_text(name, i18n_scope)
+    content_tag(:legend, class: 'form-label-bold') {
+      content_tag(:span) { t("#{i18n_scope}.#{name}.title") }
+    }
   end
 
   def clearable_radio_buttons(form, name, i18n_scope)

--- a/app/presenters/pdf/front_page_markers_presenter.rb
+++ b/app/presenters/pdf/front_page_markers_presenter.rb
@@ -17,5 +17,6 @@ module Pdf
     checkbox_group :violence,         on: :risk_information
     checkbox_group :escape,           on: :risk_information
     checkbox_group :non_association,  on: :risk_information
+    checkbox_group :open_acct,        on: :risk_information
   end
 end

--- a/app/views/escorts/_risks.html.erb
+++ b/app/views/escorts/_risks.html.erb
@@ -1,5 +1,12 @@
-<% %i[ to_self
-       violence
+<%= text_toggle_container(f, :to_self, 'risk') do %>
+  <%= form_group_container do %>
+    <%= title_text(:open_acct, 'risk') %>
+    <%= clearable_radio_buttons(f, :open_acct, 'risk') %>
+  <% end %>
+  <%= details_text_area_with_help_text(f, :to_self, 'risk') %>
+<% end %>
+
+<% %i[ violence
        from_others
        escape
        intolerant_behaviour

--- a/app/views/escorts/_risks.html.erb
+++ b/app/views/escorts/_risks.html.erb
@@ -1,4 +1,10 @@
-<% Risks::GENERAL.each do |risk| %>
+<% %i[ to_self
+       violence
+       from_others
+       escape
+       intolerant_behaviour
+       prohibited_items
+       non_association ].each do |risk| %>
   <%= render(
         'shared/toggle_with_details_field',
         f: f,

--- a/app/views/pdfs/_front_page_markers.html.erb
+++ b/app/views/pdfs/_front_page_markers.html.erb
@@ -4,17 +4,7 @@
       &nbsp
     </div>
     <div class="markers">
-      <div class="indicator">
-        <div>
-          <div class="label-inline"><%= t('.healthcare_information.acct') %></div>
-        </div>
-        <div>
-          <div class="check-box"></div>
-          <div class="label-inline">Yes</div>
-          <div class="check-box"></div>
-          <div class="label-inline">No</div>
-        </div>
-      </div>
+      <%= Pdf::CoversheetCheckbox.html_for(front_page_markers.open_acct) %>
       <div class="indicator">
         <div>
           <div class="label-inline"><%= t('.offence_information.cat_a') %></div>

--- a/config/locales/pdf.en.yml
+++ b/config/locales/pdf.en.yml
@@ -27,11 +27,11 @@ en:
         cat_a: CAT A
       healthcare_information:
         title: Healthcare information
-        acct: ACCT open
         notes: Section A3 Healthcare information
     coversheet_checkboxes:
       no_label: 'No'
       yes_label: 'Yes'
+      open_acct: ACCT open
       violence: Violence
       escape: Escort escape risk
       non_association: Non-association

--- a/config/locales/risks.en.yml
+++ b/config/locales/risks.en.yml
@@ -3,6 +3,8 @@ en:
     risks:
       heading: Risks
   risk:
+    open_acct:
+      title: Does the prisoner have an open ACCT?
     to_self:
       title: Risks to self
       help_text: Is there a risk of suicide or self-harm?

--- a/db/migrate/20160324160621_add_open_acct_to_risk_information.rb
+++ b/db/migrate/20160324160621_add_open_acct_to_risk_information.rb
@@ -1,0 +1,5 @@
+class AddOpenAcctToRiskInformation < ActiveRecord::Migration
+  def change
+    add_column :risk_information, :open_acct, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160317161206) do
+ActiveRecord::Schema.define(version: 20160324160621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20160317161206) do
     t.text     "non_association_details"
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
+    t.boolean  "open_acct"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -60,6 +60,7 @@ FactoryGirl.define do
   factory :risk_information do
     to_self true
     to_self_details 'Always ends up with scars'
+    open_acct true
     violence true
     violence_details 'Violent person'
     from_others true

--- a/spec/features/managing_an_escorts_risks_spec.rb
+++ b/spec/features/managing_an_escorts_risks_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature 'managing an escorts risks', type: :feature do
-  let(:link_name)     { 'Risks' }
-  let(:risk_category) { 'Risks to self' }
+  let(:risk_category) { 'Violence and risk to others' }
   let(:risk_text)     { 'Risky business' }
 
+  before(:each) { go_to_risks_page }
+
   scenario 'adding a risk without details' do
-    start_escort_form
-    click_link link_name
     fill_in_risk risk_category, 'Yes', nil
     click_save
 
@@ -15,8 +14,6 @@ RSpec.feature 'managing an escorts risks', type: :feature do
   end
 
   scenario 'removing a risk using the clearing option' do
-    start_escort_form
-    click_link link_name
     fill_in_risk risk_category, 'Yes', risk_text
     click_save
 
@@ -33,8 +30,6 @@ RSpec.feature 'managing an escorts risks', type: :feature do
   end
 
   scenario 'removing a risk by selecting no' do
-    start_escort_form
-    click_link link_name
     fill_in_risk risk_category, 'Yes', risk_text
     click_save
 
@@ -48,5 +43,33 @@ RSpec.feature 'managing an escorts risks', type: :feature do
     within_risk(risk_category) do
       expect(page).not_to have_content risk_text
     end
+  end
+
+  context 'within the Risks to self section' do
+    let(:open_acct_section) { 'Does the prisoner have an open ACCT?' }
+    let(:risk_category) { 'Risks to self' }
+
+    scenario 'managing whether a person has an open acct' do
+      fill_in_risk risk_category, 'Yes', risk_text
+      within_risk(open_acct_section) { choose 'Yes' }
+      click_save
+
+      within_risk(open_acct_section) do
+        expect(find_field('Yes')).to be_checked
+      end
+
+      within_risk(risk_category) { choose_first_radio 'No' }
+      click_save
+
+      # if the wrapper toggle is not true it clears out the acct radio
+      within_risk(open_acct_section) do
+        expect(find_field('Yes')).not_to be_checked
+      end
+    end
+  end
+
+  def go_to_risks_page
+    start_escort_form
+    click_link 'Risks'
   end
 end

--- a/spec/features/managing_an_escorts_risks_spec.rb
+++ b/spec/features/managing_an_escorts_risks_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'managing an escorts risks', type: :feature do
 
     within_risk(risk_category) do
       expect(page).to have_content risk_text
-      choose 'No'
+      choose_first_radio 'No'
     end
 
     click_save

--- a/spec/forms/risks_spec.rb
+++ b/spec/forms/risks_spec.rb
@@ -45,4 +45,5 @@ RSpec.describe Risks, type: :form do
         intolerant_behaviour
         prohibited_items
         non_association ])
+  it_behaves_like 'a form with maybe boolean attributes', %i[ open_acct ]
 end

--- a/spec/forms/risks_spec.rb
+++ b/spec/forms/risks_spec.rb
@@ -1,15 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Risks, type: :form do
-  general_risks = %i[ to_self violence from_others escape
-                      intolerant_behaviour prohibited_items non_association ]
-
-  describe '::GENERAL' do
-    specify do
-      expect(described_class::GENERAL).to match_array general_risks
-    end
-  end
-
   subject { described_class.new create(:escort) }
 
   input_attributes = {
@@ -46,5 +37,12 @@ RSpec.describe Risks, type: :form do
   it_behaves_like 'a form that retrives or builds its target', :risk_information
   it_behaves_like 'a form that knows what template to render', 'risks'
   it_behaves_like 'a form that belongs to an endpoint', 'risks'
-  it_behaves_like 'a form with a text toggle attribute', general_risks
+  it_behaves_like('a form with a text toggle attribute',
+    %i[ to_self
+        violence
+        from_others
+        escape
+        intolerant_behaviour
+        prohibited_items
+        non_association ])
 end

--- a/spec/forms/risks_spec.rb
+++ b/spec/forms/risks_spec.rb
@@ -45,5 +45,30 @@ RSpec.describe Risks, type: :form do
         intolerant_behaviour
         prohibited_items
         non_association ])
-  it_behaves_like 'a form with maybe boolean attributes', %i[ open_acct ]
+
+  describe '#open_acct' do
+    context 'when the risks to self marker has been set to yes' do
+      before(:each) do
+        subject.to_self = true
+      end
+
+      it_behaves_like 'a form with maybe boolean attributes', %i[ open_acct ]
+    end
+
+    { 'no' => false,
+      'empty' => nil }.each do |risk_radio_name, radio_value|
+      context "when the risks to self is set to #{risk_radio_name}" do
+        before { subject.to_self = radio_value }
+
+        { 'yes' => true,
+          'no' => false,
+          'empty' => nil }.each do |acct_radio_name, acct_value|
+          context "and the acct is set to #{acct_radio_name}" do
+            before { subject.open_acct = acct_value }
+            its(:open_acct) { is_expected.to be_nil }
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/pdf/front_page_markers_presenter_spec.rb
+++ b/spec/presenters/pdf/front_page_markers_presenter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Pdf::FrontPageMarkersPresenter, type: :presenter do
   end
 
   context 'risk information markers' do
-    %i[ violence escape non_association ].each do |checkbox|
+    %i[ open_acct violence escape non_association ].each do |checkbox|
       it 'returns a configured CoversheetCheckboxGroup instance' do
         possible_checkbox_values.each do |attribute_value|
           escort.risk_information.public_send("#{checkbox}=", attribute_value)

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe PdfGenerator, type: :service do
         and have_css('#disabilities-checkbox-group//.checked').
         and have_css('#violence-checkbox-group//.checked').
         and have_css('#violence-checkbox-group//.checked').
-        and have_css('#non_association-checkbox-group//.checked')
+        and have_css('#non_association-checkbox-group//.checked').
+        and have_css('#open_acct-checkbox-group//.checked')
     end
 
     it 'generates the expected content for the updates section' do

--- a/spec/support/feature_helpers/forms.rb
+++ b/spec/support/feature_helpers/forms.rb
@@ -11,6 +11,10 @@ module FeatureHelpers
       fill_in 'search_prisoner[prison_number]', with: prison_number
     end
 
+    def choose_first_radio(text)
+      choose(text, match: :first)
+    end
+
     def click_save
       click_button 'Save'
     end

--- a/spec/support/feature_helpers/risks_form.rb
+++ b/spec/support/feature_helpers/risks_form.rb
@@ -10,13 +10,13 @@ module FeatureHelpers
 
     def fill_in_risk(field, radio_value, textarea_value)
       within_risk(field) do
-        choose radio_value
+        choose_first_radio radio_value
         find('textarea').set textarea_value
       end
     end
 
     def clear_risk(field)
-      within_risk(field) { choose 'Clear selection' }
+      within_risk(field) { choose_first_radio 'Clear selection' }
     end
 
     def build_risk_properties

--- a/spec/support/shared/form_with_maybe_boolean_attributes.rb
+++ b/spec/support/shared/form_with_maybe_boolean_attributes.rb
@@ -1,0 +1,17 @@
+RSpec.shared_context 'a form with maybe boolean attributes' do |attributes|
+  # We should expect the subject to be a type of Escort
+  attributes.each do |attribute|
+    {
+      'true'    => true,
+      'false'   => false,
+      'unknown' => nil
+    }.each do |radio_button_value, coerced_value|
+      describe "#{attribute}=" do
+        context "coercing #{radio_button_value}" do
+          before { subject.public_send("#{attribute}=", radio_button_value) }
+          its(attribute) { is_expected.to be coerced_value }
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared/form_with_text_toggle_attribute.rb
+++ b/spec/support/shared/form_with_text_toggle_attribute.rb
@@ -2,20 +2,9 @@ RSpec.shared_examples 'a form with a text toggle attribute' do |attributes|
   let(:escort) { create(:escort) }
   subject { described_class.new(escort) }
 
-  attributes.each do |attribute|
-    {
-      'false'   => false,
-      'true'    => true,
-      'unknown' => nil
-    }.each do |radio_button_value, coerced_value|
-      describe "#{attribute}=" do
-        context "coercing #{radio_button_value}" do
-          before { subject.public_send("#{attribute}=", radio_button_value) }
-          its(attribute) { is_expected.to be coerced_value }
-        end
-      end
-    end
+  it_behaves_like 'a form with maybe boolean attributes', attributes
 
+  attributes.each do |attribute|
     let(:user_text) { 'some user entered text' }
 
     describe "##{attribute}_details=" do


### PR DESCRIPTION
- [x] Add open acct to risks form
- [x] Fix toggle with nested radio button issue(@gtvj)
- [x] Ensure ACCT is cleared if radio button is set to 'no' or cleared
- [x] Add to managing risks feature spec
- [x] Add ACCT to PDF output
# 
#### Web App
# <img width="753" alt="screen shot 2016-03-29 at 19 01 02" src="https://cloud.githubusercontent.com/assets/1006365/14118271/a84cb060-f5e0-11e5-9153-550cc150e0c1.png">
#### PDF

<img width="709" alt="screen shot 2016-03-29 at 19 02 43" src="https://cloud.githubusercontent.com/assets/1006365/14118313/e06e778a-f5e0-11e5-896c-cdced0ec2ce5.png">
