### PR TITLE
Introduce IE7 support

### DIFF
--- a/app/assets/stylesheets/ie7.scss
+++ b/app/assets/stylesheets/ie7.scss
@@ -1,0 +1,75 @@
+@import "shared_ie/global";
+@import "shared_ie/grid";
+@import "shared_ie/forms";
+
+.search-wrapper {
+  .button {
+    padding: 2px 1px 2px 0;
+    .error & {
+      padding-top: 4px;
+      padding-bottom: 4px;
+    }
+  }
+}
+
+.new_search_prisoner {
+  .field_with_errors {
+    display: inline!important;
+  }
+}
+
+
+th, td {
+  padding-right: 1em!important;
+}
+
+.button_to {
+  .button {
+    width: 9em;
+  }
+}
+
+.grid-row {
+  .column-one-quarter {
+    ul {
+      margin: 0;
+    }
+  }
+  .column-three-quarters {
+    width: 69%;
+  }
+}
+
+.error-summary {
+  padding-bottom: 1.5em;
+  ul {
+    margin: 0;
+  }
+}
+
+legend {
+  margin-left: -10px;
+}
+
+.new-risks {
+  .form-group {
+    padding-bottom: 1em;
+  }
+}
+
+.primary-nav {
+  margin-top: 19px;
+}
+
+.summary-content {
+  min-height: 200px;
+  > div {
+    min-height: 4em;
+  }
+}
+
+#prisoner-information {
+  .forenames {
+    width: 60%;
+  }
+}

--- a/app/assets/stylesheets/ie8.scss
+++ b/app/assets/stylesheets/ie8.scss
@@ -1,85 +1,18 @@
+@import "shared_ie/global";
+@import "shared_ie/grid";
+@import "shared_ie/forms";
 
-.sign-out {
-  right: 10px;
-}
-
-header h1 {
-  font-size: 48px;
-}
-
-.column-one-quarter {
-  float: left;
-  width: 25%;
-}
-
-.column-three-quarters {
-  float: left;
-  width: 75%;
-}
-
-.form-control {
-  max-width: 50%;
-}
-
-input[type="password"] {
-  font-family: sans-serif;
-}
-
-.form-group {
-  margin-bottom: 30px;
-}
-
-.form-date .form-group-year {
-  width: 90px;
-}
-
-.block-label {
-  padding-left: 40px;
-  display: inline-block;
-  float: left;
-
-  input {
-    left: 5px;
-    top: 10px;
+.grid-row {
+  .column-three-quarters {
+    width: 75%;
   }
 }
 
-.summary-content > div > div {
-  float: left;
-}
-
-.forenames {
-  width: 75%;
-}
-
-.family-name, .dob, .nationality, .prison-number, .cro-number, .pnc-number {
-  width: 25%;
-}
-
-.phase-banner {
-  width: 960px !important;
-  margin: 0 30px;
-}
-
-.age, .sex {
-  width: 12.5%;
-}
-
-.optional-section textarea {
-  min-width: 80%;
-}
-
-.phase-banner {
-  width: 960px;
-  margin: auto;
-}
-
-.container {
-  .content {
-    width: 1020px;
+.new_search_prisoner {
+  .field_with_errors {
+    input {
+      min-width: 95%;
+    }
   }
 }
 
-.search-wrapper .button {
-  padding: 0.35em 0.6em 0.3em 0.6em;
-}

--- a/app/assets/stylesheets/shared_ie/_forms.scss
+++ b/app/assets/stylesheets/shared_ie/_forms.scss
@@ -1,0 +1,51 @@
+.form-control {
+  max-width: 50%;
+}
+
+input[type="password"] {
+  font-family: sans-serif;
+}
+
+.form-group {
+  margin-bottom: 30px;
+}
+
+.form-date .form-group-year {
+  width: 90px;
+}
+
+.block-label {
+  padding-left: 40px;
+  display: inline-block;
+  float: left;
+
+  input {
+    left: 5px;
+    top: 10px;
+  }
+}
+
+.summary-content > div > div {
+  float: left;
+}
+
+.forenames {
+  width: 75%;
+}
+
+.family-name, .dob, .nationality, .prison-number, .cro-number, .pnc-number {
+  width: 25%;
+}
+
+
+.age, .sex {
+  width: 12.5%;
+}
+
+.optional-section textarea {
+  min-width: 80%;
+}
+
+.search-wrapper .button {
+  padding: 0.35em 0.6em 0.3em 0.6em;
+}

--- a/app/assets/stylesheets/shared_ie/_global.scss
+++ b/app/assets/stylesheets/shared_ie/_global.scss
@@ -1,0 +1,17 @@
+.phase-banner {
+  width: 960px !important;
+  margin: 0 30px;
+}
+
+.phase-banner {
+  width: 960px;
+  margin: auto;
+}
+
+.sign-out {
+  right: 10px;
+}
+
+header h1 {
+  font-size: 48px;
+}

--- a/app/assets/stylesheets/shared_ie/_grid.scss
+++ b/app/assets/stylesheets/shared_ie/_grid.scss
@@ -1,0 +1,14 @@
+.container {
+  .content {
+    width: 1020px;
+  }
+}
+
+.column-one-quarter {
+  float: left;
+  width: 25%;
+}
+
+.column-three-quarters {
+  float: left;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :stylesheets do %>
     <%= stylesheet_link_tag('application.css') %>
+    <!--[if IE 7]><%= stylesheet_link_tag('ie7') %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag('ie8') %><![endif]-->
     <!--[if IE 9]><%= stylesheet_link_tag('ie9') %><![endif]-->
 <% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( *.png *.ico ie8.scss ie9.scss )
+Rails.application.config.assets.precompile += %w( *.png *.ico ie7.scss ie8.scss ie9.scss )


### PR DESCRIPTION
Provide support for IE7 via a dedicated stylsheet and conditional
comments. Required changes to the overall 'old IE' approach since
there were several style fixes applicable to both IE8 and IE7.

To avoid duplication these fixes have been extracted to partials
within a 'shared_ie' directory for inclusion in browser specific
SASS files as required.
