### PR TITLE
Use CirclCI's Phantom JS

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,7 @@
 machine:
+  pre:
+    # Install PhantomJS - required for JS testing
+    - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
   ruby:
     version:
       2.3.0

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -9,7 +9,6 @@
 # end
 #
 # Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
-# Jasmine.configure do |config|
-#    config.prevent_phantom_js_auto_install = true
-# end
-#
+Jasmine.configure do |config|
+  config.prevent_phantom_js_auto_install = true
+end


### PR DESCRIPTION
This should use circles version of phantom js & as a result
should stop broken wgets from happening as the test runner
attempts to download a version of phantom js every time.
