### PR TITLE
PDF design changes

### DIFF
--- a/app/views/pdfs/_handover_details.erb
+++ b/app/views/pdfs/_handover_details.erb
@@ -64,15 +64,15 @@
         <td></td>
         <td></td>
       </tr>
+      <tr>
+        <td></td>
+        <td></td>
+      </tr>
     </table>
     <table>
       <tr>
         <th><%= t('.medical_professional') %></th>
         <th><%= t('.contact_number') %></th>
-      </tr>
-      <tr>
-        <td></td>
-        <td></td>
       </tr>
       <tr>
         <td></td>

--- a/app/views/pdfs/_record_of_handover.html.erb
+++ b/app/views/pdfs/_record_of_handover.html.erb
@@ -10,7 +10,6 @@
   </div>
   <div class="property-details">
     <div class="heading"><%= t('.property_details') %></div>
-    <div class="instructions"><%= t('.instructions') %></div>
     <ul>
       <li><strong><%= t('.cash_code') %></strong> - <%= t('.cash') %></li>
       <li><strong><%= t('.documentation_code') %></strong> - <%= t('.documentation') %></li>

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -202,7 +202,6 @@ RSpec.describe PdfGenerator, type: :service do
     it 'generates the expected content for the record of handover section' do
       expect(content).to have_content('B2. Record of handover').
         and have_content('Property, cash and medication details').
-        and have_content('Use a property code from the following list').
         and have_content('C - Cash').
         and have_content('D - Documentation').
         and have_content('IP - In possession').


### PR DESCRIPTION
Changes:
- The number of rows on different medication tables
- Removes the 'Use a property code...' handover details subtitle
