### PR TITLE
Separate shared examples based on their concerns

### DIFF
--- a/spec/forms/healthcare_form_spec.rb
+++ b/spec/forms/healthcare_form_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe HealthcareForm, type: :form do
+  subject { described_class.new(create :escort) }
+
   input_attributes = {
     physical_risk: 'true',
     physical_risk_details: 'some text',
@@ -31,25 +33,18 @@ RSpec.describe HealthcareForm, type: :form do
     medication: true
   }
 
-  it_behaves_like 'a form that syncs to a model',
+  it_behaves_like 'a form that coerces attributes',
     input_attributes, coercion_overrides
-
-  it_behaves_like 'a form that retrives or builds its target',
-    :healthcare
-
-  it_behaves_like 'a form that knows what template to render',
-    'healthcare'
-
-  it_behaves_like 'a form that belongs to an endpoint',
-    'healthcare'
-
-  toggle_fields = %i[ physical_risk mental_risk
-                      social_care_and_other allergies
-                      disabilities medication ]
+  it_behaves_like 'a form that loads model attributes on initialize'
+  it_behaves_like 'a form that syncs to a model'
+  it_behaves_like 'a form that retrives or builds its target', :healthcare
+  it_behaves_like 'a form that knows what template to render', 'healthcare'
+  it_behaves_like 'a form that belongs to an endpoint', 'healthcare'
   it_behaves_like 'a form with a text toggle attribute',
-    toggle_fields
-
-  subject { described_class.new(create :escort) }
+    %i[ physical_risk
+        mental_risk
+        social_care_and_other allergies
+        disabilities medication ]
 
   def self.falsey_permutations
     possible_attribute_values = [true, false, nil]

--- a/spec/forms/move_form_spec.rb
+++ b/spec/forms/move_form_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe MoveForm, type: :form do
-  let(:escort) { create(:escort) }
-
-  subject { described_class.new(escort) }
+  subject { described_class.new(create :escort) }
 
   input_attributes = {
     origin: 'HMP Clive House',
@@ -11,10 +9,13 @@ RSpec.describe MoveForm, type: :form do
     date_of_travel: { day: '23', month: '2', year: '2016' },
     reason: 'Expected to attend show the thing'
   }
-  coercion_overrides = { date_of_travel: Date.civil(2016, 2, 23) }
-  it_behaves_like 'a form that syncs to a model',
-    input_attributes, coercion_overrides
 
+  coercion_overrides = { date_of_travel: Date.civil(2016, 2, 23) }
+
+  it_behaves_like 'a form that coerces attributes',
+    input_attributes, coercion_overrides
+  it_behaves_like 'a form that loads model attributes on initialize'
+  it_behaves_like 'a form that syncs to a model'
   it_behaves_like 'a form that retrives or builds its target', :move
   it_behaves_like 'a form that knows what template to render', 'move'
   it_behaves_like 'a form that belongs to an endpoint', 'move'

--- a/spec/forms/offences_form_spec.rb
+++ b/spec/forms/offences_form_spec.rb
@@ -22,18 +22,13 @@ RSpec.describe OffencesForm, type: :form do
     other_offences_details: nil
   }
 
-  it_behaves_like 'a form that syncs to a model',
+  it_behaves_like 'a form that coerces attributes',
     input_attributes, coercion_overrides
-
-  it_behaves_like 'a form that retrives or builds its target',
-    :offences
-
-  it_behaves_like 'a form that knows what template to render',
-    'offences'
-
-  it_behaves_like 'a form that belongs to an endpoint',
-    'offences'
-
+  it_behaves_like 'a form that loads model attributes on initialize'
+  it_behaves_like 'a form that syncs to a model'
+  it_behaves_like 'a form that retrives or builds its target', :offences
+  it_behaves_like 'a form that knows what template to render', 'offences'
+  it_behaves_like 'a form that belongs to an endpoint', 'offences'
   it_behaves_like 'a form with a text toggle attribute',
     %i[ not_for_release must_return must_not_return other_offences ]
 end

--- a/spec/forms/prisoner_form_spec.rb
+++ b/spec/forms/prisoner_form_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe PrisonerForm, type: :form do
   let(:escort) { create(:escort) }
-
   subject { described_class.new(escort) }
 
   input_attributes = {
@@ -17,8 +16,10 @@ RSpec.describe PrisonerForm, type: :form do
 
   coercion_overrides = { date_of_birth: Date.civil(1977, 2, 10) }
 
-  it_behaves_like 'a form that syncs to a model',
+  it_behaves_like 'a form that coerces attributes',
     input_attributes, coercion_overrides
+  it_behaves_like 'a form that loads model attributes on initialize'
+  it_behaves_like 'a form that syncs to a model'
   it_behaves_like 'a form that retrives or builds its target', :prisoner
   it_behaves_like 'a form that knows what template to render', 'prisoner'
   it_behaves_like 'a form that belongs to an endpoint', 'prisoner'

--- a/spec/forms/risks_form_spec.rb
+++ b/spec/forms/risks_form_spec.rb
@@ -32,19 +32,21 @@ RSpec.describe RisksForm, type: :form do
     non_association: true
   }
 
-  it_behaves_like 'a form that syncs to a model',
+  it_behaves_like 'a form that coerces attributes',
     input_attributes, coercion_overrides
+  it_behaves_like 'a form that loads model attributes on initialize'
+  it_behaves_like 'a form that syncs to a model'
   it_behaves_like 'a form that retrives or builds its target', :risks
   it_behaves_like 'a form that knows what template to render', 'risks'
   it_behaves_like 'a form that belongs to an endpoint', 'risks'
-  it_behaves_like('a form with a text toggle attribute',
+  it_behaves_like 'a form with a text toggle attribute',
     %i[ to_self
         violence
         from_others
         escape
         intolerant_behaviour
         prohibited_items
-        non_association ])
+        non_association ]
 
   describe '#open_acct' do
     context 'when the risks to self marker has been set to yes' do

--- a/spec/support/shared/form_that_syncs_to_a_model.rb
+++ b/spec/support/shared/form_that_syncs_to_a_model.rb
@@ -1,22 +1,5 @@
-RSpec.shared_examples 'a form that syncs to a model' do |input_attributes, coerced_attribute = {}|
+RSpec.shared_examples 'a form that syncs to a model' do
   subject { described_class.new create(:escort) }
-  coerced_attributes = input_attributes.merge(coerced_attribute)
-
-  describe '#initialize' do
-    it 'loads a models attributes' do
-      form_attrs = subject.attributes.with_indifferent_access
-      model_attrs = subject.target.attributes.with_indifferent_access
-      expect(model_attrs).to include form_attrs
-    end
-  end
-
-  describe '#assign_attributes' do
-    it 'updates the attributes on the form' do
-      subject.assign_attributes(input_attributes)
-
-      expect(subject.attributes).to include(coerced_attributes)
-    end
-  end
 
   describe '#save' do
     context 'with valid attributes' do

--- a/spec/support/shared/form_with_coercion.rb
+++ b/spec/support/shared/form_with_coercion.rb
@@ -1,0 +1,12 @@
+RSpec.shared_examples 'a form that coerces attributes' do |input_attributes, coerced_attribute = {}|
+  subject { described_class.new create(:escort) }
+
+  describe '#assign_attributes' do
+    it 'updates the attributes on the form' do
+      coerced_attributes = input_attributes.merge(coerced_attribute)
+      subject.assign_attributes(input_attributes)
+
+      expect(subject.attributes).to include(coerced_attributes)
+    end
+  end
+end

--- a/spec/support/shared/form_with_initialization.rb
+++ b/spec/support/shared/form_with_initialization.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples 'a form that loads model attributes on initialize' do
+  subject { described_class.new create(:escort) }
+
+  describe '#initialize' do
+    it 'loads a models attributes' do
+      form_attrs = subject.attributes.with_indifferent_access
+      model_attrs = subject.target.attributes.with_indifferent_access
+      expect(model_attrs).to include form_attrs
+    end
+  end
+end


### PR DESCRIPTION
We now have a better organisation of the shared examples,
having separated one big shared example into 3 different
ones that test: 
- loading attributes on initialisation
- coercion of input attributes
- syncing of the form with the model
