### PR TITLE
Allow JS spec runner to work in dev mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'jasmine'
+  gem 'jasmine-jquery-rails'
 end
 
 group :test do
@@ -31,6 +33,4 @@ group :test do
   gem 'rubocop-rspec'
   gem 'rubocop', require: false
   gem 'shoulda-matchers', '~> 3.1'
-  gem 'jasmine'
-  gem 'jasmine-jquery-rails'
 end

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ and homebrew you can run the following to install it:
 
 `brew install phantomjs`
 
+Javascript specs can be run in the [browser](http://localhost:8888):
+
+`rake jasmine`
+
+Or in headless mode:
+
+`rake jasmine:ci`
+
+Javascript specs are run as part of the default rake task.
+
 #### `Testing in old IE`
 
 User research indicates that the overwhelming majority of users will access


### PR DESCRIPTION
Allows dev peepz to run JS specs:
`rake jasmine` <- run in the browser
`rake jasmine:ci` <- run headless(phantomJS)
