### PR TITLE
Infer forms target from the form name

### DIFF
--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -28,7 +28,7 @@ class Form
   end
 
   def target
-    model
+    model.public_send(name)
   end
 
 private

--- a/app/forms/healthcare_form.rb
+++ b/app/forms/healthcare_form.rb
@@ -15,8 +15,4 @@ class HealthcareForm < Form
   def mpv_required
     super && disabilities
   end
-
-  def target
-    super.healthcare
-  end
 end

--- a/app/forms/move_form.rb
+++ b/app/forms/move_form.rb
@@ -11,8 +11,4 @@ class MoveForm < Form
   def formatted_date_today
     Date.today.to_s(:day_month_year)
   end
-
-  def target
-    super.move
-  end
 end

--- a/app/forms/offences_form.rb
+++ b/app/forms/offences_form.rb
@@ -5,8 +5,4 @@ class OffencesForm < Form
   text_toggle_attribute :must_return
   text_toggle_attribute :must_not_return
   text_toggle_attribute :other_offences
-
-  def target
-    super.offences
-  end
 end

--- a/app/forms/prisoner_form.rb
+++ b/app/forms/prisoner_form.rb
@@ -10,12 +10,6 @@ class PrisonerForm < Form
   date :date_of_birth
 
   validates :date_of_birth, prisoner_age: true
-
   validates :sex, inclusion: %w[ male female ], allow_nil: true
-
   delegate :prison_number, to: :target
-
-  def target
-    super.prisoner
-  end
 end

--- a/app/forms/risks_form.rb
+++ b/app/forms/risks_form.rb
@@ -14,8 +14,4 @@ class RisksForm < Form
   def open_acct
     super if to_self
   end
-
-  def target
-    super.risks
-  end
 end


### PR DESCRIPTION
After making the forms and associated models follow a
similar pattern with regard to naming it is now possible
to infer the target(the model that receives the updates
from the form) from the forms name.
