### PR TITLE
Make UncoercedDate a value object

### DIFF
--- a/app/forms/uncoerced_date.rb
+++ b/app/forms/uncoerced_date.rb
@@ -2,8 +2,10 @@
 # fashion to Date objects so that invalid dates
 # can be displayed back to the user.
 
-class UncoercedDate < OpenStruct
-  %i[ day month year ].each do |method_name|
-    define_method(method_name) { super() }
-  end
+class UncoercedDate
+  include Virtus.value_object
+
+  attribute :day, String
+  attribute :month, String
+  attribute :year, String
 end

--- a/spec/forms/uncoerced_date_spec.rb
+++ b/spec/forms/uncoerced_date_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+require 'rails_helper'
 
-RSpec.describe UncoercedDate, type: :presenter do
+RSpec.describe UncoercedDate, type: :form do
   methods = %i[ day month year ]
 
   context 'when provided a nil value' do


### PR DESCRIPTION
UncoercedDate instances are only ever read by the view
so this model fits being a value object. The resulting
class is much more readable.

This commit also fixes running the uncoerced_date_spec
on its own as it was requiring the wrong helper.
