### PR TITLE
Repopulate healthcare form on validation errors

### DIFF
--- a/app/forms/healthcare_form.rb
+++ b/app/forms/healthcare_form.rb
@@ -29,7 +29,7 @@ class HealthcareForm < Form
   end
 
   def backfilled_medications
-    target.backfilled_medications(MedicationForm)
+    target.backfilled_medications(medications)
   end
 
   def carrier_options

--- a/app/models/healthcare.rb
+++ b/app/models/healthcare.rb
@@ -6,8 +6,13 @@ class Healthcare < ActiveRecord::Base
   has_many :medications
   accepts_nested_attributes_for :medications, allow_destroy: true
 
-  def backfilled_medications(klass = Medication)
-    number_to_backfill = MAX_MEDICATIONS_COUNT - medications.size
-    medications + Array.new(number_to_backfill) { klass.new }
+  def backfilled_medications(medication_forms = [])
+    filled_objects = if medication_forms.any?
+                       medication_forms
+                     else
+                       medications
+                     end
+    number_to_backfill = MAX_MEDICATIONS_COUNT - filled_objects.size
+    filled_objects + Array.new(number_to_backfill) { Medication.new }
   end
 end

--- a/spec/models/healthcare_spec.rb
+++ b/spec/models/healthcare_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Healthcare, type: :model do
     let(:klass) { MedicationForm }
 
     context 'when there are no persisted medication models' do
-      it 'returns a fixed size array of empty objects of the passed class' do
+      it 'returns a fixed size array of empty medications' do
         subject.medications.destroy_all
 
-        expect(subject.backfilled_medications(MedicationForm)).
+        expect(subject.backfilled_medications).
           to satisfy do |meds|
             meds.size == array_size &&
-              meds.all? { |m| m.is_a?(klass) } &&
+              meds.all? { |m| m.is_a?(Medication) } &&
               meds.none?(&:persisted?)
           end
       end
@@ -39,6 +39,20 @@ RSpec.describe Healthcare, type: :model do
             meds.size == array_size &&
               meds.count(&:persisted?) == 2 &&
               meds.all? { |m| m.is_a?(Medication) }
+          end
+      end
+    end
+
+    context 'when medication forms are passed in' do
+      it 'returns an array of medication forms padded with empty medications' do
+        medication_forms = Array.new(2) { MedicationForm.new }
+
+        expect(subject.backfilled_medications(medication_forms)).
+          to satisfy do |meds|
+            meds.size == array_size &&
+              meds.count(&:persisted?) == 0 &&
+              meds.count { |m| m.is_a?(MedicationForm) } == 2 &&
+              meds.count { |m| m.is_a?(Medication) } == 4
           end
       end
     end


### PR DESCRIPTION
When a validation error occurs on a nested model
(medication) we were repopulating the form with
persisted medications, not the values that were
previously inserted.
