### PR TITLE
Add a quick action to the UI to lookup another PER

### DIFF
--- a/app/views/shared/_quick_actions.html.erb
+++ b/app/views/shared/_quick_actions.html.erb
@@ -3,4 +3,7 @@
   <ul>
     <li><%= link_to(t('quick_actions.preview'), pdf_path(escort)) %></li>
   </ul>
+  <ul>
+    <li><%= link_to(t('quick_actions.find_prisoner'), root_path) %></li>
+  </ul>
 </div>

--- a/config/locales/navigation.en.yml
+++ b/config/locales/navigation.en.yml
@@ -10,3 +10,4 @@ en:
   quick_actions:
     heading: Quick actions
     preview: Preview PER
+    find_prisoner: Find a prisoner

--- a/spec/features/completing_escort_spec.rb
+++ b/spec/features/completing_escort_spec.rb
@@ -12,12 +12,22 @@ RSpec.feature 'completing digital person escort record', type: :feature do
     expect(current_path).to match expected_path
   end
 
+  scenario 'leaving the current PER in order to start another' do
+    start_escort_form
+    fill_in_prisoner
+    click_button 'Save'
+
+    click_link 'Find a prisoner'
+    expect(current_path).to eq root_path
+  end
+
   scenario 'filling in the prisoner prisoner page' do
     start_escort_form
 
     expect(page).to have_heading 'Prisoner Information'
 
     expect(page).to have_preview_per_link
+    expect(page).to have_find_prisoner_link
 
     fill_in_prisoner
 
@@ -33,6 +43,7 @@ RSpec.feature 'completing digital person escort record', type: :feature do
     expect(page).to have_heading 'Risks'
 
     expect(page).to have_preview_per_link
+    expect(page).to have_find_prisoner_link
 
     fill_in_risks
 
@@ -48,6 +59,7 @@ RSpec.feature 'completing digital person escort record', type: :feature do
     expect(page).to have_heading 'Move Information'
 
     expect(page).to have_preview_per_link
+    expect(page).to have_find_prisoner_link
 
     fill_in_move
 
@@ -63,6 +75,7 @@ RSpec.feature 'completing digital person escort record', type: :feature do
     expect(page).to have_heading 'Healthcare'
 
     expect(page).to have_preview_per_link
+    expect(page).to have_find_prisoner_link
 
     fill_in_healthcare
 
@@ -84,6 +97,7 @@ RSpec.feature 'completing digital person escort record', type: :feature do
     expect(page).to have_heading 'Summary'
 
     expect(page).to have_preview_per_link
+    expect(page).to have_find_prisoner_link
 
     expect(page).to have_text('Prisoner Information').
       and have_link('Edit', href: prisoner_path(escort)).

--- a/spec/support/matchers/find_prisoner_link.rb
+++ b/spec/support/matchers/find_prisoner_link.rb
@@ -1,0 +1,12 @@
+RSpec::Matchers.define :have_find_prisoner_link do
+  match do |page|
+    link_text = I18n.t('quick_actions.find_prisoner')
+    @actual = page.find('a', text: link_text)[:href]
+    @expected = root_path(escort)
+    @actual == @expected
+  end
+
+  failure_message do
+    "Expected to find #{@expected} but found #{@actual}"
+  end
+end


### PR DESCRIPTION
Clicking the link takes the user to the search page

<img width="407" alt="screen shot 2016-04-21 at 12 32 31" src="https://cloud.githubusercontent.com/assets/1006365/14707532/307ce426-07bd-11e6-9d4f-9cc94c4e3dc8.png">
