### PR TITLE
Accommodate long origin / destination names on PDF

### DIFF
--- a/app/views/pdfs/_record_of_handover.html.erb
+++ b/app/views/pdfs/_record_of_handover.html.erb
@@ -39,7 +39,7 @@
           <th>&#163; <%= t('.value') %></th>
           <th><%= t('.initial') %></th>
         </tr>
-        <% 10.times do %>
+        <% 9.times do %>
             <tr>
               <td></td>
               <td></td>
@@ -57,7 +57,7 @@
           <th><%= render('pdfs/clock_image') %></th>
           <th><%= t('.initial') %></th>
         </tr>
-        <% 10.times do %>
+        <% 9.times do %>
             <tr>
               <td></td>
               <td></td>


### PR DESCRIPTION
MS noted this morning that layout for Handover section splits across pages when a long origin or destination name is provided. Having discussed the lack of space with JP it seems the most appropriate
response is to reduce the number of rows above to accommodate. Having tested it seems removing a single row fixes the issue.

<img width="612" alt="screen shot 2016-04-28 at 17 30 32" src="https://cloud.githubusercontent.com/assets/16000203/14893582/e1af8e92-0d67-11e6-8c94-639766aeafbc.png">
